### PR TITLE
Fix for Sctp stream Id and UE Security capabilities

### DIFF
--- a/build-config
+++ b/build-config
@@ -9,12 +9,12 @@ ROOT=$(PWD)
 INCLUDE_DIR=$(ROOT)/include
 
 INC_DIRS=-I$(INCLUDE_DIR)/mme-app -I$(INCLUDE_DIR)/s11 -I$(INCLUDE_DIR)/s1ap \
-	-I$(INCLUDE_DIR)/s6a \
+	-I$(INCLUDE_DIR)/s6a -I$(ROOT)/../freediameter/build/include -I$(ROOT)/../freediameter/include\
 	-I$(INCLUDE_DIR)/common
 
 HSS_INC_DIRS = -I$(INCLUDE_DIR)/common -I$(INCLUDE_DIR)/hss
 
-CC := gcc
+CC := gcc -L/home/cord/bad/mme/freediameter/build/libfdproto -L/home/cord/bad/mme/freediameter/build/libfdcore
 
 #DEBUG=true
 DEBUG=false

--- a/include/common/hashtable.h
+++ b/include/common/hashtable.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2003-2019, Great Software Laboratory Pvt. Ltd.
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HASHTABLE_H_
+#define HASHTABLE_H_
+
+#include "stdbool.h"
+#define ONF_HT_PRIME_1 151
+#define ONF_HT_PRIME_2 163
+#define ONF_HT_INITIAL_BASE_SIZE 53
+
+typedef struct {
+	int key_len;
+	int val_len;
+	char* key;
+	char* value;
+} onf_ht_item;
+
+typedef struct {
+    int base_size;
+    int size;
+    int count;
+    onf_ht_item** items;
+} onf_ht_hash_table;
+
+int         onf_ht_insert(
+               onf_ht_hash_table* ht, int k_len, int v_len, 
+	       const char* key, const char* value);
+bool        onf_key_compare(
+               int k_len, int key_len, 
+	       const char* k, const char* key);
+char*       onf_ht_search(onf_ht_hash_table* ht, 
+                   const char* key, int key_len);
+int         onf_ht_delete(onf_ht_hash_table* h, 
+                   const char* key, int key_len);
+int         onf_ht_hash(const char* s, int len_s, 
+                          const int a, const int m);
+int         onf_ht_get_hash(
+               const char* s, int key_len,
+	       const int num_buckets, const int attempt);
+void        onf_ht_del_item(onf_ht_item* i);
+void        onf_ht_del_hash_table(onf_ht_hash_table* ht);
+onf_ht_hash_table*        onf_ht_new();
+onf_ht_item*       onf_ht_new_item(int k_len, int s_len,
+                             const char* k, const char* v);
+onf_ht_hash_table* onf_ht_new_sized(const int base_size);
+int onf_ht_resize(
+            onf_ht_hash_table* ht, const int base_size);
+int onf_ht_resize_up(onf_ht_hash_table* ht);
+int onf_ht_resize_down(onf_ht_hash_table* ht);
+
+#endif /* HASHTABLE_H__*/

--- a/include/common/prime.h
+++ b/include/common/prime.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2018, Great Software Laboratory Pvt. Ltd.
+ * Copyright (c) 2003-2019, Great Software Laboratory Pvt. Ltd.
  * Copyright (c) 2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,17 +15,12 @@
  * limitations under the License.
  */
 
-/*
- * options.h
- *
- */
+#ifndef PRIME_H_
+#define PRIME_H_
 
-#ifndef OPTIONS_H_
-#define OPTIONS_H_
+#include "stdbool.h"
 
-#define REQ_ARGS 0x0000
-void parse_args(int argc, char **argv);
-int  send_sctp_msg_upd(int enb_fd, 
-                        unsigned char *buffer, size_t len);
+bool onf_is_prime(int x);
+int onf_next_prime(int x);
 
-#endif /* OPTIONS_H_ */
+#endif

--- a/include/common/s1ap_structs.h
+++ b/include/common/s1ap_structs.h
@@ -70,7 +70,40 @@ struct esm_sec_info {
 	struct proto_conf proto_config;
 };
 
+/*ENB association information*/
+struct enb_assoc_info {
+	int enb_fd;
+	int inStreamId;
+	int outStreamId;
+	int assoc_max_out_streams;
+	int assoc_max_in_streams;
+	int assocId;
+};
+
+/*NAS MSG IE CODES */
+/* Message content : 
+   3gpp 24.301
+   Table 8.2.4.1: IEI Column.*/
+typedef enum
+{
+    NAS_IE_TYPE_EPS_MOBILE_ID_IMSI=0x1,
+    NAS_IE_TYPE_UE_NETWORK_CAPABILITY=0x2,
+    NAS_IE_TYPE_ESM_MSG=0x3,
+    NAS_IE_TYPE_TMSI_STATUS=0x9,
+    NAS_IE_TYPE_MS_NETWORK_FEATURE_SUPPORT=0xC,
+    NAS_IE_TYPE_GUTI_TYPE=0xE,
+    NAS_IE_TYPE_ADDITIONAL_UPDATE_TYPE=0xF,
+    NAS_IE_TYPE_MS_CLASSMARK_2=0x11,
+    NAS_IE_TYPE_LAI=0x13,
+    NAS_IE_TYPE_PTMSI_SIGNATURE=0x19,
+    NAS_IE_TYPE_MS_CLASSMARK_3=0x20,
+    NAS_IE_TYPE_MS_NETWORK_CAPABILITY=0x31,
+    NAS_IE_TYPE_DRX_PARAM=0x5C,
+    NAS_IE_TYPE_VOICE_DOMAIN_PREF_UE_USAGE_SETTING=0x5D,
+}nas_ie_type;
+
 typedef struct MS_net_capab {
+        bool          pres;
 	unsigned char element_id;
 	unsigned char len;
 	unsigned char capab[6];
@@ -260,6 +293,7 @@ typedef struct esm_msg_container {
 	uint8_t procedure_trans_identity;
 	uint8_t session_management_msgs;
 	uint8_t eps_qos;  /* TODO: Revisit 24.301 - 9.9.4.3.1 */
+	bool    esm_info_tx_required;
 	struct apn_name apn;
 	pdn_address pdn_addr;
 	linked_transcation_id linked_ti;
@@ -387,7 +421,7 @@ typedef struct eRAB_elements {
 /**eRAB structures end**/
 
 /**Information elements structs end**/
-typedef union nas_pdu_elements {
+typedef union nas_pdu_elements_union {
 	unsigned char rand[NAS_RAND_SIZE];
 	unsigned char autn[NAS_AUTN_SIZE];
 	unsigned char IMSI[BINARY_IMSI_LEN];
@@ -406,7 +440,11 @@ typedef union nas_pdu_elements {
 	esm_msg_container esm_msg;
 	guti mi_guti;
 	bool esm_info_tx_required;
-	unsigned char pti;
+}nas_pdu_elements_union;
+
+typedef struct nas_pdu_elements {
+   nas_ie_type msgType;
+   nas_pdu_elements_union pduElement;
 }nas_pdu_elements;
 
 typedef struct nasPDU {

--- a/include/common/stage3_info.h
+++ b/include/common/stage3_info.h
@@ -34,7 +34,8 @@ struct authresp_Q_msg {
 struct sec_mode_Q_msg {
 	int ue_idx;
 	int enb_s1ap_ue_id;
-	struct UE_net_capab ue_network;
+	struct UE_net_capab  ue_network;
+	struct MS_net_capab  ms_net_capab;
 	struct KASME key;
 	uint8_t int_key[NAS_INT_KEY_SIZE];
 	uint32_t dl_seq_no;

--- a/include/s1ap/s1ap.h
+++ b/include/s1ap/s1ap.h
@@ -31,7 +31,10 @@ int
 parse_IEs(char *msg, struct proto_IE *proto_ies, unsigned short proc_code);
 
 int
-s1_setup_handler(char *msg, int enb_fd);
+s1_setup_handler(char *msg, int enb_fd, int inStreamId);
+
+int
+addEnbInfoToHash(int enbfd, int inStreamId);
 
 int
 s1_init_ue_handler(struct proto_IE *s1_init_ies, int enb_fd);

--- a/include/s1ap/sctp_conn.h
+++ b/include/s1ap/sctp_conn.h
@@ -31,9 +31,11 @@ int create_sctp_socket(unsigned int remote_ip, unsigned short port);
 
 int accept_sctp_socket(int sockfd);
 
-int recv_sctp_msg(int sockfd, unsigned char *buf, size_t len);
+int recv_sctp_msg(int sockfd, struct sctp_sndrcvinfo *sndrcvinfo, unsigned char *buf, size_t len);
 
 int send_sctp_msg(int sockfd, unsigned char *buf, size_t len);
+int send_sctp_req_msg(int sockfd, int streamId, 
+                       unsigned char *buf, size_t len);
 
 int close_sctp_socket(int sockfd);
 

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -31,6 +31,7 @@ endif
 IF_LIBNAME = libinterface.so
 JSON_PARSER_LIBNAME = libjson.so
 LOG_LIBNAME = liblog.a
+HASHTABLE_LIBNAME = libhash.a
 TPOOL_LIBNAME = libthreadpool.a
 UTIL_LIBNAME = libsecutil.so
 
@@ -39,11 +40,13 @@ LOG_SRC = log.c
 TPOOL_SRC = thread_pool.c tpool_queue.c
 JSON_PARSER_SRC = json_parser.c
 UTIL_SRC = snow_3g.c f8.c f9.c
+HASH_SRC = hashtable.c prime.c
 
 build_s6a:
 	$(CC) $(CFLAGS) -fPIC -c $(IF_SRC) $(INC_DIRS)
 	$(CC) $(CFLAGS) -fPIC -c $(LOG_SRC) $(INC_DIRS)
 	$(CC) $(CFLAGS) -fPIC -c $(TPOOL_SRC) $(INC_DIRS)
+	$(CC) $(CFLAGS) -fPIC -c $(HASH_SRC) $(INC_DIRS)
 	$(CC) $(CFLAGS) -fPIC -c $(JSON_PARSER_SRC) $(INC_DIRS)
 	$(CC) $(CFLAGS) -fPIC -c $(UTIL_SRC) $(INC_DIRS)
 	$(CC) $(CFLAGS) ipc_api.o -shared -o $(IF_LIBNAME)
@@ -51,6 +54,7 @@ build_s6a:
 	$(CC) $(CFLAGS) snow_3g.o f8.o f9.o -shared -o $(UTIL_LIBNAME)
 	ar rcs $(LOG_LIBNAME) log.o
 	ar rcs $(TPOOL_LIBNAME) thread_pool.o tpool_queue.o
+	ar rcs $(HASHTABLE_LIBNAME) hashtable.o prime.o
 
 all: build_s6a
 
@@ -61,6 +65,7 @@ install:all
 	-@cp $(LOG_LIBNAME) $(TARGET_DIR)/lib
 	-@cp $(JSON_PARSER_LIBNAME) $(TARGET_DIR)/lib
 	-@cp $(UTIL_LIBNAME) $(TARGET_DIR)/lib
+	-@cp $(HASHTABLE_LIBNAME) $(TARGET_DIR)/lib
 
 clean:
 	rm -f *.o

--- a/src/common/hashtable.c
+++ b/src/common/hashtable.c
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2003-2018, Great Software Laboratory Pvt. Ltd.
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "prime.h"
+#include "err_codes.h"
+#include "hashtable.h"
+
+static onf_ht_item ONF_HT_DELETED_ITEM = {0,0,NULL, NULL};
+
+/*****************************************
+Name:  onf_ht_new_item
+brief: Create new hash item
+return: onf_ht_item
+*****************************************/
+onf_ht_item* onf_ht_new_item(
+     int k_len, int v_len, 
+     const char* k, const char* v) 
+{
+    onf_ht_item* i = malloc(sizeof(onf_ht_item));
+    if(NULL == i)
+    {
+       return NULL; 
+    }
+
+    i->key_len = k_len;
+    i->val_len = v_len;
+    i->key = (char*)malloc(k_len);
+    if(NULL == i->key)
+    {
+       free(i);
+       return NULL;
+    }
+    memcpy(i->key, k, k_len);
+    i->value = (char*)malloc(v_len);
+    if(NULL == i->value)
+    {
+       free(i->key);
+       free(i);
+       return NULL;
+    }
+    memcpy(i->value, v, v_len);
+    return i;
+}
+
+/*****************************************
+Name:  onf_ht_new
+brief: Create new hash table
+return: onf_ht_hash_table
+*****************************************/
+onf_ht_hash_table* onf_ht_new() {
+    return onf_ht_new_sized(ONF_HT_INITIAL_BASE_SIZE);
+}
+
+
+/*****************************************
+Name:  onf_ht_new_sized
+brief: Create new hash table with new size
+return: onf_ht_hash_table
+*****************************************/
+onf_ht_hash_table* onf_ht_new_sized(const int base_size) {
+    onf_ht_hash_table* ht = malloc(sizeof(onf_ht_hash_table));
+    if(NULL == ht)
+    {
+        return NULL;
+    }
+
+    ht->base_size = base_size;
+    ht->size = onf_next_prime(ht->base_size);
+
+    ht->count = 0;
+    ht->items = calloc((size_t)ht->size, sizeof(onf_ht_item*));
+    if(NULL == ht->items)
+    {
+        free(ht);
+	return NULL;
+    }
+
+    return ht;
+}
+
+/*****************************************
+Name:  onf_ht_resize
+brief: resize hash table with new size
+return: 
+*****************************************/
+int onf_ht_resize(
+         onf_ht_hash_table* ht, const int base_size) 
+{
+    if (base_size < ONF_HT_INITIAL_BASE_SIZE) {
+        return E_FAIL;
+    }
+
+    onf_ht_hash_table* new_ht = onf_ht_new_sized(base_size);
+    if(NULL == new_ht)
+    {
+        return E_ALLOC_FAILED;
+    }
+
+    for (int i = 0; i < ht->size; i++) {
+        onf_ht_item* item = ht->items[i];
+        if (item != NULL && item != &ONF_HT_DELETED_ITEM) {
+            if(SUCCESS != onf_ht_insert(new_ht, item->key_len,
+	      item->val_len, item->key, item->value))
+	    {
+                onf_ht_del_hash_table(new_ht);
+	        return E_FAIL;
+	    }
+        }
+    }
+
+    ht->base_size = new_ht->base_size;
+    ht->count = new_ht->count;
+
+    // To delete new_ht, we give it ht's size and items 
+    const int tmp_size = ht->size;
+    ht->size = new_ht->size;
+    new_ht->size = tmp_size;
+
+    onf_ht_item** tmp_items = ht->items;
+    ht->items = new_ht->items;
+    new_ht->items = tmp_items;
+
+    onf_ht_del_hash_table(new_ht);
+    return SUCCESS;
+}
+
+/*****************************************
+Name:  onf_ht_resize_up
+brief: resize up 
+return: 
+*****************************************/
+int onf_ht_resize_up(onf_ht_hash_table* ht) {
+    const int new_size = ht->base_size * 2;
+    return onf_ht_resize(ht, new_size);
+}
+
+/*****************************************
+Name:  onf_ht_resize_down
+brief: resize down
+return: 
+*****************************************/
+int onf_ht_resize_down(onf_ht_hash_table* ht) {
+    const int new_size = ht->base_size / 2;
+    return onf_ht_resize(ht, new_size);
+}
+
+/*****************************************
+Name:  onf_ht_del_item
+brief: delete hash item
+return: 
+*****************************************/
+void onf_ht_del_item(onf_ht_item* i) {
+    free(i->key);
+    free(i->value);
+    free(i);
+}
+
+/*****************************************
+Name:  onf_ht_del_hash_table
+brief: delete hash table
+return: 
+*****************************************/
+void onf_ht_del_hash_table(onf_ht_hash_table* ht) {
+    for (int i = 0; i < ht->size; i++) {
+        onf_ht_item* item = ht->items[i];
+        if (item != NULL) {
+            onf_ht_del_item(item);
+        }
+    }
+    free(ht->items);
+    free(ht);
+}
+
+/*****************************************
+Name:  onf_ht_hash
+brief: Calculate hash value.
+return: 
+*****************************************/
+int onf_ht_hash(
+      const char* s, int len_s, const int a, const int m) 
+{
+    long hash = 0;
+    for (int i = 0; i < len_s; i++) {
+        hash += (long)pow(a, len_s - (i+1)) * s[i];
+        hash = hash % m;
+    }
+    return (int)hash;
+}
+
+/*****************************************
+Name:  onf_ht_get_hash
+brief: get hash table index from key
+return: 
+*****************************************/
+int onf_ht_get_hash(
+    const char* s, int key_len, 
+    const int num_buckets, const int attempt) 
+{
+    const int hash_a = onf_ht_hash(
+                        s, key_len, ONF_HT_PRIME_1, num_buckets);
+    const int hash_b = onf_ht_hash(
+                        s, key_len, ONF_HT_PRIME_2, num_buckets);
+    return (hash_a + (attempt * (hash_b + 1))) % num_buckets;
+}
+
+/*****************************************
+Name:  onf_ht_insert
+brief: insert into hash table
+return: 
+*****************************************/
+int onf_ht_insert(
+      onf_ht_hash_table* ht, int key_len,  
+      int val_len, const char* key, const char* value) 
+{
+    const int load = (ht->count * 100) / ht->size;
+    if (load > 70) {
+        if(SUCCESS != onf_ht_resize_up(ht))
+	{
+	    return E_FAIL;
+	}
+    }
+    onf_ht_item* item = onf_ht_new_item(
+                         key_len, val_len,key, value);
+    if(NULL == item)
+    {
+       return E_ALLOC_FAILED;
+    }
+    int index = onf_ht_get_hash(item->key, 
+                   item->key_len,ht->size, 0);
+    onf_ht_item* cur_item = ht->items[index];
+    int i = 1;
+    while (cur_item != NULL) {
+        if(cur_item != &ONF_HT_DELETED_ITEM) {
+            if (onf_key_compare(
+	          cur_item->key_len, key_len,
+		      cur_item->key, key)) {
+                onf_ht_del_item(cur_item);
+                ht->items[index] = item;
+                return SUCCESS;
+            }
+            else
+            {
+		index = onf_ht_get_hash(item->key, 
+		           item->key_len, ht->size, i);
+		cur_item = ht->items[index];
+		i++;
+            }
+        }
+    } 
+    ht->items[index] = item;
+    ht->count++;
+    return SUCCESS;
+}
+
+/*****************************************
+Name:  onf_htsearch
+brief: search key in hash table
+return: 
+*****************************************/
+char* onf_ht_search(onf_ht_hash_table* ht, const char* key, int key_len) {
+    int index = onf_ht_get_hash(key, key_len, ht->size, 0);
+    onf_ht_item* item = ht->items[index];
+    int i = 1;
+    while (item != NULL) {
+        if(item != &ONF_HT_DELETED_ITEM) {
+            if (onf_key_compare(
+	          item->key_len, key_len, item->key, key)) 
+            {
+                return item->value;
+            }
+        }
+        index = onf_ht_get_hash(key, key_len, ht->size, i);
+        item = ht->items[index];
+        i++;
+    } 
+    return NULL;
+}
+
+/*****************************************
+Name:  onf_ht_delete
+brief: delete from hash table
+return: 
+*****************************************/
+int onf_ht_delete(
+        onf_ht_hash_table* ht, 
+	const char* key, int key_len) 
+{
+    const int load = (ht->count * 100) / ht->size;
+    if (load <= 10) {
+        if(SUCCESS != onf_ht_resize_down(ht))
+	{
+	    return E_FAIL;
+	}
+    }
+    int index = onf_ht_get_hash(key, key_len, ht->size, 0);
+    onf_ht_item* item = ht->items[index];
+    int i = 1;
+    while (item != NULL) {
+        if (item != &ONF_HT_DELETED_ITEM) {
+            if (onf_key_compare(
+	          item->key_len, key_len, item->key, key))
+	    {
+                onf_ht_del_item(item);
+                ht->items[index] = &ONF_HT_DELETED_ITEM;
+		break;
+            }
+        }
+        index = onf_ht_get_hash(key, key_len, ht->size, i);
+        item = ht->items[index];
+        i++;
+    } 
+    ht->count--;
+    return SUCCESS;
+}
+
+/*****************************************
+Name:  onf_key_compare
+brief: compare keys hash table
+return: 
+*****************************************/
+bool onf_key_compare(
+               int k_len, int key_len, 
+	       const char* k, const char* key)
+{
+    if((k_len != key_len) || 
+         (memcmp(k, key, key_len) != 0))
+    {
+        return false;
+    }
+
+    return true;
+}

--- a/src/common/prime.c
+++ b/src/common/prime.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2003-2018, Great Software Laboratory Pvt. Ltd.
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <math.h>
+#include "prime.h"
+
+#if 0
+/*****************************************
+ * Return whether value is prime or not
+ *
+ * Returns:
+ *   1  = prime
+ *   0  = not prime
+ *   -1 = undefined (i.e. x < 2)
+*****************************************/
+int onf_is_prime(const int x) {
+    if (x < 2) { return -1; }
+    if (x < 4) { return 1; }
+    if ((x % 2) == 0) { return 0; }
+    for (int i = 3; i <= floor(sqrt((double) x)); i += 2) {
+        if ((x % i) == 0) {
+            return 0;
+        }
+    }
+    return 1;
+}
+#endif
+
+/*****************************************
+ * Return whether value is prime or not
+ *
+ * Returns:
+ *   true  = prime
+ *   false  = not prime
+*****************************************/
+bool onf_is_prime(int n) 
+{ 
+    if (n <= 1)  return false; 
+    if (n <= 3)  return true; 
+  
+    if (n%2 == 0 || n%3 == 0) return false; 
+  
+    for (int i=5; i*i<=n; i=i+6) 
+    {
+        if (n%i == 0 || n%(i+2) == 0)
+        {
+           return false;
+        }
+    }
+  
+    return true; 
+} 
+
+/*****************************************
+ * Return the next prime after x, or x if x is prime
+*****************************************/
+int onf_next_prime(int x) {
+    while (onf_is_prime(x) != true) {
+        x++;
+    }
+    return x;
+}

--- a/src/mme-app/handlers/attach_authresp.c
+++ b/src/mme-app/handlers/attach_authresp.c
@@ -152,6 +152,8 @@ post_to_next()
 	sec_mode_msg.enb_s1ap_ue_id = ue_entry->s1ap_enb_ue_id;
 	memcpy(&(sec_mode_msg.ue_network), &(ue_entry->ue_net_capab),
 		sizeof(struct UE_net_capab));
+	memcpy(&(sec_mode_msg.ms_net_capab), &(ue_entry->ms_net_capab),
+		sizeof(struct MS_net_capab));
 
 	memcpy(&(sec_mode_msg.key), &(ue_entry->aia_sec_info->kasme),
 		sizeof(struct KASME));

--- a/src/s1ap/Makefile
+++ b/src/s1ap/Makefile
@@ -50,7 +50,9 @@ LIBS := -lpthread	\
 	-linterface \
 	-llog \
 	-lthreadpool \
+	-lhash \
 	-ljson \
+	-lm \
 	-lsecutil
 
 $(TARGET): $(OBJECTS)

--- a/src/s1ap/handlers/attach_authreq.c
+++ b/src/s1ap/handlers/attach_authreq.c
@@ -23,6 +23,7 @@
 
 #include "log.h"
 #include "err_codes.h"
+#include "options.h"
 #include "s1ap.h"
 #include "message_queues.h"
 #include "ipc_api.h"
@@ -119,9 +120,9 @@ get_authreq_protoie_value(struct proto_IE *value)
 	value->data[2].nas.elements = (nas_pdu_elements *)
 			malloc(AUTH_REQ_NO_OF_NAS_IES * sizeof(nas_pdu_elements));
 
-	memcpy(value->data[2].nas.elements[0].rand,
+	memcpy(value->data[2].nas.elements[0].pduElement.rand,
 			g_authreqInfo->rand, NAS_RAND_SIZE);
-	memcpy(value->data[2].nas.elements[1].autn,
+	memcpy(value->data[2].nas.elements[1].pduElement.autn,
 			g_authreqInfo->autn, NAS_AUTN_SIZE);
 
 
@@ -229,14 +230,16 @@ authreq_processing()
 	buffer_copy(&g_nas_buffer, &nas->header.nas_security_param,
 						sizeof(nas->header.nas_security_param));
 
-	buffer_copy(&g_nas_buffer, &nas->elements[0].rand,
-						sizeof(nas->elements[0].rand));
+	buffer_copy(&g_nas_buffer, 
+	     &nas->elements[0].pduElement.rand,
+	     sizeof(nas->elements[0].pduElement.rand));
 
 	datalen = 16;
 	buffer_copy(&g_nas_buffer, &datalen, sizeof(datalen));
 
-	buffer_copy(&g_nas_buffer, &nas->elements[1].autn,
-						sizeof(nas->elements[1].autn));
+	buffer_copy(&g_nas_buffer, 
+	   &nas->elements[1].pduElement.autn,
+	   sizeof(nas->elements[1].pduElement.autn));
 
 	datalen = g_nas_buffer.pos + 1;
 	buffer_copy(&g_value_buffer, &datalen,
@@ -267,7 +270,8 @@ authreq_processing()
 static int
 post_to_next()
 {
-	send_sctp_msg(g_authreqInfo->enb_fd, g_buffer.buf, g_buffer.pos);
+	send_sctp_msg_upd(
+	       g_authreqInfo->enb_fd, g_buffer.buf, g_buffer.pos);
 	log_msg(LOG_INFO, "\n-----Stage2 completed.---\n");
 	return SUCCESS;
 }

--- a/src/s1ap/handlers/attach_authresp.c
+++ b/src/s1ap/handlers/attach_authresp.c
@@ -58,8 +58,8 @@ s1_auth_resp_handler(struct proto_IE *s1_auth_resp_ies)
 	else
 		auth_resp.status = SUCCESS;
 
-	memcpy(&(auth_resp.res), &(s1_auth_resp_ies->data[2].nas.elements[0].auth_resp),
-		sizeof(struct XRES));
+	memcpy(&(auth_resp.res), 
+	   &(s1_auth_resp_ies->data[2].nas.elements[0].pduElement.auth_resp), sizeof(struct XRES));
 
 	//STIMER_GET_CURRENT_TP(g_attach_stats[s1_auth_resp_ies->data[1].enb_ue_s1ap_id].auth_to_mme);
 	write_ipc_channel(ipcHndl_authresp, (char *)&auth_resp, S1AP_AUTHRESP_STAGE3_BUF_SIZE);

--- a/src/s1ap/handlers/attach_esmreq.c
+++ b/src/s1ap/handlers/attach_esmreq.c
@@ -23,6 +23,7 @@
 #include <stdint.h>
 
 #include "err_codes.h"
+#include "options.h"
 #include "message_queues.h"
 #include "ipc_api.h"
 #include "main.h"
@@ -270,7 +271,7 @@ esmreq_processing()
 static int
 post_to_next()
 {
-	send_sctp_msg(g_esmReqInfo->enb_fd, g_esm_buffer.buf, g_esm_buffer.pos);
+	send_sctp_msg_upd(g_esmReqInfo->enb_fd, g_esm_buffer.buf, g_esm_buffer.pos);
 	log_msg(LOG_INFO, "\n-----Stage4 completed.---\n");
 
 	return SUCCESS;

--- a/src/s1ap/handlers/attach_esmresp.c
+++ b/src/s1ap/handlers/attach_esmresp.c
@@ -56,7 +56,7 @@ s1_esm_resp_handler(struct proto_IE *s1_esm_resp_ies)
 	else
 		esm_resp.status = SUCCESS;
 
-	memcpy(&(esm_resp.apn), &(s1_esm_resp_ies->data[2].nas.elements[0].apn),
+	memcpy(&(esm_resp.apn), &(s1_esm_resp_ies->data[2].nas.elements[0].pduElement.apn),
 		sizeof(struct apn_name));
 
 	int i = write_ipc_channel(ipcHndl_esmresp, (char *)&esm_resp, S1AP_ESMRESP_STAGE5_BUF_SIZE);

--- a/src/s1ap/handlers/attach_icsreq.c
+++ b/src/s1ap/handlers/attach_icsreq.c
@@ -24,6 +24,7 @@
 
 #include "log.h"
 #include "err_codes.h"
+#include "options.h"
 #include "message_queues.h"
 #include "ipc_api.h"
 #include "s1ap_config.h"
@@ -184,52 +185,52 @@ get_icsreq_protoie_value(struct proto_IE *value)
 			malloc(ICS_REQ_NO_OF_NAS_IES * sizeof(nas_pdu_elements));
 
 	nas_pdu_elements *nasIEs = e_rab->nas.elements;
-	nasIEs[nasIeCnt].attach_res = 1; /* EPS Only */
+	nasIEs[nasIeCnt].pduElement.attach_res = 1; /* EPS Only */
 	nasIeCnt++;
 
-	nasIEs[nasIeCnt].t3412 = 16;
+	nasIEs[nasIeCnt].pduElement.t3412 = 16;
 	nasIeCnt++;
 
-	nasIEs[nasIeCnt].tailist.type = 1;
-	nasIEs[nasIeCnt].tailist.num_of_elements = 0;
-	memcpy(&(nasIEs[nasIeCnt].tailist.partial_list[0]),
+	nasIEs[nasIeCnt].pduElement.tailist.type = 1;
+	nasIEs[nasIeCnt].pduElement.tailist.num_of_elements = 0;
+	memcpy(&(nasIEs[nasIeCnt].pduElement.tailist.partial_list[0]),
 			&(g_icsReqInfo->tai), sizeof(g_icsReqInfo->tai));
 	nasIeCnt++;
 
-	nasIEs[nasIeCnt].esm_msg.eps_bearer_id = 5; /* TODO: revisit */
-	nasIEs[nasIeCnt].esm_msg.proto_discriminator = 2;
-	memcpy(&(nasIEs[nasIeCnt].esm_msg.procedure_trans_identity), &(g_icsReqInfo->pti), 1);
-	nasIEs[nasIeCnt].esm_msg.session_management_msgs =
+	nasIEs[nasIeCnt].pduElement.esm_msg.eps_bearer_id = 5; /* TODO: revisit */
+	nasIEs[nasIeCnt].pduElement.esm_msg.proto_discriminator = 2;
+	memcpy(&(nasIEs[nasIeCnt].pduElement.esm_msg.procedure_trans_identity), &(g_icsReqInfo->pti), 1);
+	nasIEs[nasIeCnt].pduElement.esm_msg.session_management_msgs =
 			ESM_MSG_ACTV_DEF_BEAR__CTX_REQ;
-	nasIEs[nasIeCnt].esm_msg.eps_qos = 9;
+	nasIEs[nasIeCnt].pduElement.esm_msg.eps_qos = 9;
 
 	/* TODO: Remove hardcoded value */
 	/*char apnname[4] = "apn1";
 	memcpy(&(nasIEs[nasIeCnt].esm_msg.apn.val), apnname, 4);
 	nasIEs[nasIeCnt].esm_msg.apn.len =  4;
 	*/
-	nasIEs[nasIeCnt].esm_msg.apn.len = g_icsReqInfo->apn.len;
-	memcpy(nasIEs[nasIeCnt].esm_msg.apn.val,
+	nasIEs[nasIeCnt].pduElement.esm_msg.apn.len = g_icsReqInfo->apn.len;
+	memcpy(nasIEs[nasIeCnt].pduElement.esm_msg.apn.val,
 			g_icsReqInfo->apn.val, g_icsReqInfo->apn.len);
 
 
-	nasIEs[nasIeCnt].esm_msg.pdn_addr.type = 1;
-	nasIEs[nasIeCnt].esm_msg.pdn_addr.ipv4 =
+	nasIEs[nasIeCnt].pduElement.esm_msg.pdn_addr.type = 1;
+	nasIEs[nasIeCnt].pduElement.esm_msg.pdn_addr.ipv4 =
 			g_icsReqInfo->pdn_addr.ip_type.ipv4.s_addr;
-	nasIEs[nasIeCnt].esm_msg.linked_ti.flag = 0;
-	nasIEs[nasIeCnt].esm_msg.linked_ti.val = 0;
-	get_negotiated_qos_value(&nasIEs[nasIeCnt].esm_msg.negotiated_qos);
+	nasIEs[nasIeCnt].pduElement.esm_msg.linked_ti.flag = 0;
+	nasIEs[nasIeCnt].pduElement.esm_msg.linked_ti.val = 0;
+	get_negotiated_qos_value(&nasIEs[nasIeCnt].pduElement.esm_msg.negotiated_qos);
 	nasIeCnt++;
 
-	nasIEs[nasIeCnt].mi_guti.odd_even_indication = 0;
-	nasIEs[nasIeCnt].mi_guti.id_type = 6;
-	memcpy(&(nasIEs[nasIeCnt].mi_guti.plmn_id),
+	nasIEs[nasIeCnt].pduElement.mi_guti.odd_even_indication = 0;
+	nasIEs[nasIeCnt].pduElement.mi_guti.id_type = 6;
+	memcpy(&(nasIEs[nasIeCnt].pduElement.mi_guti.plmn_id),
 			&(g_icsReqInfo->tai.plmn_id), sizeof(struct PLMN));
-	nasIEs[nasIeCnt].mi_guti.mme_grp_id = htons(g_s1ap_cfg.mme_group_id);
-	nasIEs[nasIeCnt].mi_guti.mme_code = g_s1ap_cfg.mme_code;
+	nasIEs[nasIeCnt].pduElement.mi_guti.mme_grp_id = htons(g_s1ap_cfg.mme_group_id);
+	nasIEs[nasIeCnt].pduElement.mi_guti.mme_code = g_s1ap_cfg.mme_code;
 	/* TODO : Revisit, temp fix for handling detach request retransmit.
 	 * M-TMSI should come from MME */
-	nasIEs[nasIeCnt].mi_guti.m_TMSI = htonl(g_icsReqInfo->ue_idx);
+	nasIEs[nasIeCnt].pduElement.mi_guti.m_TMSI = htonl(g_icsReqInfo->ue_idx);
 	nasIeCnt++;
 
 	ieCnt++;
@@ -460,18 +461,18 @@ icsreq_processing()
 	nas_pdu_elements *ies = erab->nas.elements;
 
 	/* eps attach result */
-	buffer_copy(&g_ics_buffer, &(ies[0].attach_res), sizeof(u8value));
+	buffer_copy(&g_ics_buffer, &(ies[0].pduElement.attach_res), sizeof(u8value));
 
 	/* GPRS timer */
-	buffer_copy(&g_ics_buffer, &(ies[1].t3412), sizeof(ies[1].t3412));
+	buffer_copy(&g_ics_buffer, &(ies[1].pduElement.t3412), sizeof(ies[1].pduElement.t3412));
 
 	/* TAI list */
 	u8value = 6;
 	buffer_copy(&g_ics_buffer, &u8value, sizeof(u8value));
 	u8value = 32; /* TODO: use value from tai list */
 	buffer_copy(&g_ics_buffer, &u8value, sizeof(u8value));
-	buffer_copy(&g_ics_buffer, &(ies[2].tailist.partial_list[0].plmn_id.idx), 3);
-	buffer_copy(&g_ics_buffer, &(ies[2].tailist.partial_list[0].tac), 2);
+	buffer_copy(&g_ics_buffer, &(ies[2].pduElement.tailist.partial_list[0].plmn_id.idx), 3);
+	buffer_copy(&g_ics_buffer, &(ies[2].pduElement.tailist.partial_list[0].tac), 2);
 
 	esm_len_pos = g_ics_buffer.pos;
 
@@ -482,23 +483,23 @@ icsreq_processing()
 	/* ESM message container start */
 
 	/* esm message bearer id and protocol discriminator */
-	u8value = (ies[3].esm_msg.eps_bearer_id << 4 |
-			ies[3].esm_msg.proto_discriminator);
+	u8value = (ies[3].pduElement.esm_msg.eps_bearer_id << 4 |
+			ies[3].pduElement.esm_msg.proto_discriminator);
 	buffer_copy(&g_ics_buffer, &u8value, sizeof(u8value));
 
 	/* esm message procedure identity */
-	buffer_copy(&g_ics_buffer, &(ies[3].esm_msg.procedure_trans_identity),
-			sizeof(ies[3].esm_msg.procedure_trans_identity));
+	buffer_copy(&g_ics_buffer, &(ies[3].pduElement.esm_msg.procedure_trans_identity),
+			sizeof(ies[3].pduElement.esm_msg.procedure_trans_identity));
 
 	/* esm message session management message */
-	buffer_copy(&g_ics_buffer, &(ies[3].esm_msg.session_management_msgs),
-			sizeof(ies[3].esm_msg.session_management_msgs));
+	buffer_copy(&g_ics_buffer, &(ies[3].pduElement.esm_msg.session_management_msgs),
+			sizeof(ies[3].pduElement.esm_msg.session_management_msgs));
 
 	/* eps qos */
 	datalen = 1;
 	buffer_copy(&g_ics_buffer, &datalen, sizeof(datalen));
-	buffer_copy(&g_ics_buffer, &(ies[3].esm_msg.eps_qos),
-			sizeof(ies[3].esm_msg.eps_qos));
+	buffer_copy(&g_ics_buffer, &(ies[3].pduElement.esm_msg.eps_qos),
+			sizeof(ies[3].pduElement.esm_msg.eps_qos));
 
 	/* apn */
 	{
@@ -521,21 +522,21 @@ icsreq_processing()
 	u8value = 1;
 	buffer_copy(&g_ics_buffer, &u8value, sizeof(u8value));
 	//buffer_copy(&g_ics_buffer, &(ies[3].esm_msg.pdn_addr.pdn_type), 1);
-	buffer_copy(&g_ics_buffer, &(ies[3].esm_msg.pdn_addr.ipv4), datalen-1);
+	buffer_copy(&g_ics_buffer, &(ies[3].pduElement.esm_msg.pdn_addr.ipv4), datalen-1);
 
 	/* linked ti */
 	u8value = 0x5d; /* element id TODO: define macro or enum */
 	buffer_copy(&g_ics_buffer, &u8value, sizeof(u8value));
 	datalen = 1;//sizeof(ies[3].esm_msg.linked_ti);
 	buffer_copy(&g_ics_buffer, &datalen, sizeof(datalen));
-	buffer_copy(&g_ics_buffer, &(ies[3].esm_msg.linked_ti), datalen);
+	buffer_copy(&g_ics_buffer, &(ies[3].pduElement.esm_msg.linked_ti), datalen);
 
 	/* negotiated qos */
 	u8value = 0x30; /* element id TODO: define macro or enum */
 	buffer_copy(&g_ics_buffer, &u8value, sizeof(u8value));
 	datalen = 16;//sizeof(ies[3].esm_msg.negotiated_qos);
 	buffer_copy(&g_ics_buffer, &datalen, sizeof(datalen));
-	buffer_copy(&g_ics_buffer, &(ies[3].esm_msg.negotiated_qos), datalen);
+	buffer_copy(&g_ics_buffer, &(ies[3].pduElement.esm_msg.negotiated_qos), datalen);
 
 	/* apn ambr */
 #if 0
@@ -575,13 +576,13 @@ icsreq_processing()
 	buffer_copy(&g_ics_buffer, &datalen, sizeof(datalen));
 	u8value = 246; /* TODO: remove hard coding */
 	buffer_copy(&g_ics_buffer, &u8value, sizeof(u8value));
-	buffer_copy(&g_ics_buffer, &(ies[4].mi_guti.plmn_id.idx), 3);
-	buffer_copy(&g_ics_buffer, &(ies[4].mi_guti.mme_grp_id),
-			sizeof(ies[4].mi_guti.mme_grp_id));
-	buffer_copy(&g_ics_buffer, &(ies[4].mi_guti.mme_code),
-			sizeof(ies[4].mi_guti.mme_code));
-	buffer_copy(&g_ics_buffer, &(ies[4].mi_guti.m_TMSI),
-			sizeof(ies[4].mi_guti.m_TMSI));
+	buffer_copy(&g_ics_buffer, &(ies[4].pduElement.mi_guti.plmn_id.idx), 3);
+	buffer_copy(&g_ics_buffer, &(ies[4].pduElement.mi_guti.mme_grp_id),
+			sizeof(ies[4].pduElement.mi_guti.mme_grp_id));
+	buffer_copy(&g_ics_buffer, &(ies[4].pduElement.mi_guti.mme_code),
+			sizeof(ies[4].pduElement.mi_guti.mme_code));
+	buffer_copy(&g_ics_buffer, &(ies[4].pduElement.mi_guti.m_TMSI),
+			sizeof(ies[4].pduElement.mi_guti.m_TMSI));
 
 	/* E_RABToBeSetupListCtxtSUReq NAS PDU end */
 
@@ -648,7 +649,7 @@ icsreq_processing()
 static int
 post_to_next()
 {
-	send_sctp_msg(g_icsReqInfo->enb_fd, g_ics_buffer.buf, g_ics_buffer.pos);
+	send_sctp_msg_upd(g_icsReqInfo->enb_fd, g_ics_buffer.buf, g_ics_buffer.pos);
 	log_msg(LOG_INFO, "buffer size is %d\n", g_ics_buffer.pos);
 	log_msg(LOG_INFO, "\n-----Stage6 completed.---\n");
 	return SUCCESS;

--- a/src/s1ap/handlers/attach_secreq.c
+++ b/src/s1ap/handlers/attach_secreq.c
@@ -23,6 +23,7 @@
 #include <stdint.h>
 
 #include "err_codes.h"
+#include "options.h"
 #include "message_queues.h"
 #include "ipc_api.h"
 #include "log.h"
@@ -132,12 +133,43 @@ get_secreq_protoie_value(struct proto_IE *value)
 	value->data[2].nas.elements = (nas_pdu_elements *)
 			malloc(SEC_MODE_NO_OF_NAS_IES * sizeof(nas_pdu_elements));
 
-	value->data[2].nas.elements->ue_network.len =
+	value->data[2].nas.elements->pduElement.ue_network.len =
 			g_secReqInfo->ue_network.len;
+	if(g_secReqInfo->ue_network.len >= 4)
+	{
+	    if(g_secReqInfo->ms_net_capab.pres == true)
+	    {
+	        /*The MS Network capability contains the GEA
+		* capability. The MSB of 1st Byte and the 2nd to
+		* 7th Bit of 2nd byte contain the GEA info.
+		* Thus the masks 0x7F : for GEA/1
+		* and mask 0x7D: for GEA2 -GEA7
+		*/
+	        value->data[2].nas.elements->pduElement.ue_network.len = 5;
+		char val = 0x00;
+		val = g_secReqInfo->ms_net_capab.capab[0]&0x7F;
+                val |= g_secReqInfo->ms_net_capab.capab[1]&0x7D;
+	        value->data[2].nas.elements->pduElement.ue_network.capab[4] = val;
+	    }
+	    else
+	    {
+	        /*If MS capability is not present. Then only 
+		* Capability till UMTS Algorithms is sent.*/
+	        value->data[2].nas.elements->pduElement.ue_network.len = 4;
+	    }
 
-	memcpy(value->data[2].nas.elements->ue_network.capab,
+            /*Copy first 4 bytes of security algo info*/
+	    memcpy(value->data[2].nas.elements->pduElement.ue_network.capab, g_secReqInfo->ue_network.capab, 4);
+	}
+	else
+	{
+	    /*Copy as much info of UE network capability 
+	    * as received.
+	    */
+            memcpy(value->data[2].nas.elements->pduElement.ue_network.capab,
 			g_secReqInfo->ue_network.capab,
 			g_secReqInfo->ue_network.len);
+	}
 
 	return SUCCESS;
 }
@@ -194,11 +226,11 @@ secreq_processing()
 	buffer_copy(&g_sec_nas_buffer, &nas.header.nas_security_param,
 			sizeof(nas.header.nas_security_param));
 
-	buffer_copy(&g_sec_nas_buffer, &nas.elements->ue_network.len,
-			sizeof(nas.elements->ue_network.len));
+	buffer_copy(&g_sec_nas_buffer, &nas.elements->pduElement.ue_network.len,
+			sizeof(nas.elements->pduElement.ue_network.len));
 
-	buffer_copy(&g_sec_nas_buffer, &nas.elements->ue_network.capab,
-			nas.elements->ue_network.len);
+	buffer_copy(&g_sec_nas_buffer, &nas.elements->pduElement.ue_network.capab,
+			nas.elements->pduElement.ue_network.len);
 
 	/* Calculate mac */
 	uint8_t direction = 1;
@@ -300,7 +332,7 @@ secreq_processing()
 static int
 post_to_next()
 {
-	send_sctp_msg(g_secReqInfo->enb_fd, g_sec_buffer.buf, g_sec_buffer.pos);
+	send_sctp_msg_upd(g_secReqInfo->enb_fd, g_sec_buffer.buf, g_sec_buffer.pos);
 	log_msg(LOG_INFO, "\n-----Stage3 completed.---\n");
 	return SUCCESS;
 }

--- a/src/s1ap/handlers/detach_req.c
+++ b/src/s1ap/handlers/detach_req.c
@@ -56,7 +56,7 @@ detach_stage1_handler(struct proto_IE *detach_ies, bool retransmit)
 	if (!retransmit)
 		req.ue_idx = detach_ies->data[0].mme_ue_s1ap_id;
 	else
-		req.ue_idx = ntohl(detach_ies->data[1].nas.elements[0].mi_guti.m_TMSI);
+		req.ue_idx = ntohl(detach_ies->data[1].nas.elements[0].pduElement.mi_guti.m_TMSI);
 
 	write_ipc_channel(ipcHndl_detach, (char *)&req, S1AP_DETACHREQ_STAGE1_BUF_SIZE);
 

--- a/src/s1ap/sctp_conn.c
+++ b/src/s1ap/sctp_conn.c
@@ -91,13 +91,13 @@ int accept_sctp_socket(int connSock)
 	return accept(connSock, (struct sockaddr *) NULL, (socklen_t *) NULL);
 }
 
-int recv_sctp_msg(int connSock, unsigned char *buffer, size_t len)
+int recv_sctp_msg(int connSock, struct sctp_sndrcvinfo *sndrcvinfo, unsigned char *buffer, size_t len)
 {
-	struct sctp_sndrcvinfo sndrcvinfo;
+	//struct sctp_sndrcvinfo sndrcvinfo;
 	int flags;
 
 	return sctp_recvmsg(connSock, buffer, len,
-			(struct sockaddr *) NULL, 0, &sndrcvinfo, &flags);
+			(struct sockaddr *) NULL, 0, sndrcvinfo, &flags);
 }
 
 int send_sctp_msg(int connSock, unsigned char *buffer, size_t len)
@@ -105,6 +105,15 @@ int send_sctp_msg(int connSock, unsigned char *buffer, size_t len)
 	uint32_t ppid = S1AP_PPID;
 	return sctp_sendmsg(connSock, (void *)buffer, len,
 			NULL, 0, htonl(ppid), 0, 0, 0, 0);
+}
+
+int send_sctp_req_msg(
+    int connSock, int streamId, 
+    unsigned char *buffer, size_t len)
+{
+    uint32_t ppid = S1AP_PPID;
+    return sctp_sendmsg(connSock, (void *)buffer, len,
+			NULL, 0, htonl(ppid), 0, streamId, 0, 0);
 }
 
 int close_sctp_socket(int connSock)


### PR DESCRIPTION
The Following fixes have been made:
1. Updated the way UE Security capabilities is replayed in Security mode command. It should consider the UE network capabilities and the MS network capabilities if received.
 - To enable this, nas pdu elements structure has been updated to have a flag to see if an optional parameter is received or not. (MS network capability is optional)

2. Updated the code to avoid having hardcoded SCTP stream ID for UE messages. Now we will have a stream Id counter per ENodeB. The ENodeB structure is maintained in a hashtable and the outStreamId is incremented per enodeb for every Init Ue message.  
 - To enable this, hashtable function has been added to store Association info per EnodeB.
