### PR TITLE
Timer support in openmme #29

### DIFF
--- a/include/common/local_timer.h
+++ b/include/common/local_timer.h
@@ -1,0 +1,48 @@
+/*
+* Copyright 2019-present Open Networking Foundation
+*
+* SPDX-License-Identifier: Apache-2.0
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+#ifndef __LOCAL_TIMER_H__
+#define __LOCAL_TIMER_H__
+
+/* Timeout callback function signature */
+typedef void (*cbf)(void *);
+
+/* API to start timer. For now we are supporting timers only in seconds. ms timers can be 
+ * added but does not seem to be requirement for now.
+ * Callback data is completely transparent to timerlib. Timer lib never dereferrences the
+ * content of it 
+ * Return : keep the pointer safe. Dont mess it up. Its timer handle. Which is link list node 
+ * as of now. But can be changed in future if performance becomes issue */
+
+void* start_timer(unsigned int timeout, cbf callback, void *callback_data);
+
+/* Pass the timer handle to stop the timer. Dont expect any callback once this event is
+ * called. There is possibility of race condition, which can be handled if timerstop is called
+ * at the same time when timer is expired.  */
+int stop_timer(void *timer );
+
+/* If app wish to check if timer is running and valid then it can call this API. */
+int timer_running(void *timer);
+
+/* One time activity. Can be called from any thread once. Typically main thread should initialize it 
+ * before any thread calls any of the other timer APIs */
+
+void init_timer_lib();
+
+#endif

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -33,12 +33,14 @@ JSON_PARSER_LIBNAME = libjson.so
 LOG_LIBNAME = liblog.a
 TPOOL_LIBNAME = libthreadpool.a
 UTIL_LIBNAME = libsecutil.so
+TIMER_LIBNAME = liblocaltimer.so
 
 IF_SRC=ipc_api.c
 LOG_SRC = log.c
 TPOOL_SRC = thread_pool.c tpool_queue.c
 JSON_PARSER_SRC = json_parser.c
 UTIL_SRC = snow_3g.c f8.c f9.c
+TIMER_SRC = local_timer.c
 
 build_s6a:
 	$(CC) $(CFLAGS) -fPIC -c $(IF_SRC) $(INC_DIRS)
@@ -46,9 +48,11 @@ build_s6a:
 	$(CC) $(CFLAGS) -fPIC -c $(TPOOL_SRC) $(INC_DIRS)
 	$(CC) $(CFLAGS) -fPIC -c $(JSON_PARSER_SRC) $(INC_DIRS)
 	$(CC) $(CFLAGS) -fPIC -c $(UTIL_SRC) $(INC_DIRS)
+	$(CC) $(CFLAGS) -fPIC -c $(TIMER_SRC) $(INC_DIRS)
 	$(CC) $(CFLAGS) ipc_api.o -shared -o $(IF_LIBNAME)
 	$(CC) $(CFLAGS) json_parser.o -shared -o $(JSON_PARSER_LIBNAME)
 	$(CC) $(CFLAGS) snow_3g.o f8.o f9.o -shared -o $(UTIL_LIBNAME)
+	$(CC) $(CFLAGS) local_timer.o -shared -o $(TIMER_LIBNAME)
 	ar rcs $(LOG_LIBNAME) log.o
 	ar rcs $(TPOOL_LIBNAME) thread_pool.o tpool_queue.o
 
@@ -61,6 +65,7 @@ install:all
 	-@cp $(LOG_LIBNAME) $(TARGET_DIR)/lib
 	-@cp $(JSON_PARSER_LIBNAME) $(TARGET_DIR)/lib
 	-@cp $(UTIL_LIBNAME) $(TARGET_DIR)/lib
+	-@cp $(TIMER_LIBNAME) $(TARGET_DIR)/lib
 
 clean:
 	rm -f *.o

--- a/src/common/local_timer.c
+++ b/src/common/local_timer.c
@@ -1,0 +1,426 @@
+/*
+* Copyright 2019-present Open Networking Foundation
+*
+* SPDX-License-Identifier: Apache-2.0
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* Version - 0.1
+* This file has timer implementation.
+* Timer library creates one pthread and works in that thread context.
+* Callbacks are made in the timer Thread context. Application needs
+* to handle the locking mechanism if any. 
+* Granularity of timer is in seconds...
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/timerfd.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <poll.h>
+#include <assert.h>
+#include "local_timer.h"
+
+#define INSIDE_APP_CALLBACK 0x0001
+#define IS_CONTROL_INSIDE_CALLBACK(node) ((node->flags) & 0x0001)
+#define SET_CONTROL_INSIDE_CALLBACK(node) ((node->flags) |= 0x0001)
+#define RESET_CONTROL_INSIDE_CALLBACK(node) ((node->flags) &= 0xFFFE)
+
+struct timer 
+{
+   uint64_t id;
+   void *cb_data;
+   cbf  cbf;
+   uint64_t timeout;
+   uint16_t ms_offset;
+   struct timer *next, *prev;
+   uint16_t flags;
+};
+
+static struct timer *head = NULL;
+static uint64_t sec_epoch = 0;
+static uint16_t ms_epoch=0;
+static pthread_mutex_t timer_lock;
+
+
+/* Doubly link list Code...Manages adding/removing timers 
+ */
+static void insert_node(struct timer *node)
+{
+   struct timer *temp=NULL, *prev=NULL;
+
+   pthread_mutex_lock(&timer_lock); 
+
+   if(head == NULL)
+   {
+     head = node;
+     pthread_mutex_unlock(&timer_lock); 
+     return;
+   }
+   temp=head;
+   while(temp != NULL) 
+   {
+     if((node->timeout < temp->timeout) || 
+        ((node->timeout == temp->timeout) && (node->ms_offset < temp->ms_offset)))
+     {
+       node->prev = temp->prev;
+       node->next = temp;
+       if(temp->prev)
+         temp->prev->next = node;
+       temp->prev = node;
+       if(temp == head)
+       {
+         head = node;
+       }
+       pthread_mutex_unlock(&timer_lock); 
+       return;
+     }
+     prev = temp;
+     temp = temp->next;
+   }
+   if(temp == NULL)
+   {
+     prev->next = node;
+     node->prev = prev; 
+   }
+   pthread_mutex_unlock(&timer_lock); 
+   return;
+}
+
+static int 
+find_node(struct timer *node)
+{
+  struct timer *temp = NULL; 
+
+  pthread_mutex_lock(&timer_lock); 
+  for(temp = head; (temp != NULL) && (temp != node); temp = temp->next);
+  pthread_mutex_unlock(&timer_lock); 
+  return ((temp != NULL) ? 0 : -1);
+}
+
+/* end of doubly link list Code */
+
+static void check_expired_timers()
+{
+  struct timer *temp=NULL;
+  pthread_mutex_lock(&timer_lock); 
+  temp = head;
+  while(temp != NULL)
+  {
+    if(temp->timeout > sec_epoch)
+    {
+      pthread_mutex_unlock(&timer_lock); 
+      return; // nothing to timeout 
+    }
+    if((temp->timeout == sec_epoch) && temp->ms_offset > ms_epoch)
+    {
+      pthread_mutex_unlock(&timer_lock); 
+      return; // nothing to timeout
+    }
+
+    head = head->next; 
+
+    if(head)
+      head->prev = NULL;
+
+    // temp is now not part of the list  
+    SET_CONTROL_INSIDE_CALLBACK(temp);
+    pthread_mutex_unlock(&timer_lock); 
+    temp->cbf(temp->cb_data);
+    RESET_CONTROL_INSIDE_CALLBACK(temp);
+    free(temp);
+    pthread_mutex_lock(&timer_lock); 
+    temp = head;
+  } 
+  pthread_mutex_unlock(&timer_lock); 
+  return;
+}
+
+
+static void* init_lib(void *t)
+{
+  struct itimerspec timeout;
+  uint64_t buf[2];
+  int buf_len;
+  
+  printf("Inside init lib \n");
+  int fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK);
+  if(fd < 0) 
+  {
+    printf("Error in creating timer fd \n");
+  }
+  printf("Timer FD created %d \n",fd);
+
+  /* We need tick per 100 ms.. (10 ticks/second) */
+  timeout.it_interval.tv_nsec = 100000000;  /* Interval for periodic timer */
+  timeout.it_interval.tv_sec  = 0 ; /* Interval for periodic timer */
+  timeout.it_value.tv_sec = 1;     /* Initial expiration */
+
+  if(timerfd_settime(fd, 0, &timeout, NULL)<0)
+  {
+    printf("Error in setting timer\n");
+  }
+  printf("timerfd_Settime success \n");
+  struct pollfd fds[1];
+  int ret;
+  
+  fds[0].fd = fd;
+  fds[0].events = POLLIN;
+  while(1)
+  {
+    ret = poll(fds, 1, 100); // wait for 100 msec for the event 
+    if(ret >= 0)
+    {
+      if(ret > 0 && fds[0].revents & POLLIN)
+      {
+        //printf("\nRead event Received \n");
+        buf_len = read(fd, &buf, sizeof(uint64_t));
+        if(buf_len != sizeof(uint64_t))
+        {
+          //error
+        }
+      }
+      ms_epoch++;
+      ms_epoch = ms_epoch % 10;
+      if(ms_epoch == 0)
+      {
+        sec_epoch++; // 1 sec complete ...
+      }
+      check_expired_timers();
+    }
+  }
+  return NULL;
+}
+
+#ifdef STANDALONE_TIMER_PROGRAM
+/* Its upto application to handle this timer event... 
+ * Since timer library is creates its own thread,
+ * callback is made inside the timerthread context
+ */
+static uint64_t expired_timers = 0;
+static void my_ut_timer(void *p)
+{
+  expired_timers++;
+  return;
+}
+
+static void timer_callback_call_timer_stop(void *p)
+{
+  expired_timers++;
+  stop_timer(p);
+}
+
+static void timer_callback_call_timer_start(void *p)
+{
+  expired_timers++;
+  start_timer(10, my_ut_timer, NULL);
+}
+
+
+int main()
+{
+  init_timer_lib();
+  // Execute Our UT when program runs as standalone...
+  sleep(2); 
+  {
+    /* Test 1 - Start timer and let it expire */
+    printf("START TEST1- Timer is start/expire test started \n");
+    struct timer *tmr = start_timer(10, my_ut_timer, NULL);
+    assert(tmr != NULL);
+    sleep(1);
+    assert(timer_running(tmr) == 0);
+    sleep(10);
+    assert(timer_running(tmr) == -1);
+    printf("END - Timer is start/expire passed\n");
+  }
+
+  {
+    /* Test 2 - Start timer and stop timer */
+    printf("START TEST2 Timer is start/stop test started \n");
+    struct timer *tmr = start_timer(10, my_ut_timer, NULL);
+    assert(tmr != NULL);
+    sleep(1);
+    assert(timer_running(tmr) == 0);
+    assert(stop_timer(tmr) == 0);
+    assert(timer_running(tmr) == -1);
+    printf("END Timer is start/stop passed\n");
+  }
+  {
+    /* Test 3 - Start 5 timers */
+    printf("START TEST3 -  5 timers start test started \n");
+    uint64_t expired_timers_local = expired_timers;
+    start_timer(10, my_ut_timer, NULL);
+    start_timer(15, my_ut_timer, NULL);
+    start_timer(8, my_ut_timer, NULL);
+    start_timer(1, my_ut_timer, NULL);
+    start_timer(2, my_ut_timer, NULL);
+    sleep(16);
+    assert(expired_timers == (expired_timers_local + 5));
+    // we should have all my_ut_timers must have expired by now.. 
+    printf("END - 5 timers start test passed \n");
+  }  
+  {
+    /* Test 4 - Start timer and stop timer in between */
+    printf("START TEST4 - 5 timers start & stop one of the timer started \n");
+    uint64_t expired_timers_local = expired_timers;
+    struct timer *tmr = start_timer(10, my_ut_timer, NULL);
+    start_timer(15, my_ut_timer, NULL);
+    start_timer(8, my_ut_timer, NULL);
+    start_timer(1, my_ut_timer, NULL);
+    start_timer(2, my_ut_timer, NULL);
+    stop_timer(tmr);
+    sleep(16);
+    assert(expired_timers == (expired_timers_local + 4));
+    // we should have all my_ut_timers must have expired by now.. 
+    printf("END 5 timers start & stop 1 timer test passed \n");
+  }    
+  {
+    /* Test 5 - Start timer and stop timer in between */
+    printf("START TEST5 - 5 timers start & stop one of the timer started \n");
+    uint64_t expired_timers_local = expired_timers;
+    struct timer *tmr = start_timer(18, my_ut_timer, NULL);
+    start_timer(15, my_ut_timer, NULL);
+    start_timer(8, my_ut_timer, NULL);
+    start_timer(1, my_ut_timer, NULL);
+    start_timer(2, my_ut_timer, NULL);
+    stop_timer(tmr);
+    sleep(19);
+    assert(expired_timers == (expired_timers_local + 4));
+    // we should have all my_ut_timers must have expired by now.. 
+    printf("END 5 timers start & stop 1 timer test passed \n");
+  }  
+  {
+    /* Test 6 - Start timer and stop timer in between */
+    printf("START TEST6 - 5 timers start & stop one of the timer started \n");
+    uint64_t expired_timers_local = expired_timers;
+    struct timer *tmr;
+    start_timer(10, my_ut_timer, NULL);
+    start_timer(15, my_ut_timer, NULL);
+    start_timer(8, my_ut_timer, NULL);
+    start_timer(7, my_ut_timer, NULL);
+    tmr = start_timer(2, my_ut_timer, NULL);
+    stop_timer(tmr);
+    sleep(16);
+    assert(expired_timers == (expired_timers_local + 4));
+    // we should have all my_ut_timers must have expired by now.. 
+    printf("END - 5 timers start & stop 1 timer test passed \n");
+  } 
+  {
+    /* Test 7 - Start timer and expiry callback calls stop timer */
+    printf("START TEST7 - start 1 timer and in timer expiry callback, stop timer is called \n");
+    uint64_t expired_timers_local = expired_timers;
+    struct timer *tmr = start_timer(2, timer_callback_call_timer_stop, NULL);
+    tmr->cb_data = tmr; //hack for testcase  
+    sleep(6);
+    assert(expired_timers == (expired_timers_local + 1));
+    // we should have all my_ut_timers must have expired by now.. 
+    printf("END - TEST7... test passed \n");
+  }  
+  {
+    /* Test 7 - Start timer and expiry callback calls stop timer */
+    printf("START TEST8 - start 1 timer and in timer expiry callback, start one more timer \n");
+    uint64_t expired_timers_local = expired_timers;
+    struct timer *tmr;
+    tmr = start_timer(2, timer_callback_call_timer_start, NULL);
+    sleep(16);
+    assert(expired_timers == (expired_timers_local + 2));
+    // we should have all my_ut_timers must have expired by now.. 
+    printf("END - TEST8... test passed \n");
+  }  
+
+  while(1) 
+  {
+    sleep(1);
+  }
+  return 0;
+}
+#endif
+
+/* Public Timer APIs*/
+void* start_timer(unsigned int timeout, 
+            cbf callback, 
+            void *callback_data)
+{
+  struct timer *node;
+  static uint64_t id;
+  node = calloc(1, sizeof(struct timer));
+  node->id = id++;
+  node->timeout = sec_epoch + timeout;
+  node->ms_offset = ms_epoch;
+  node->cb_data = callback_data;
+  node->cbf = callback;
+  insert_node(node);
+  return (void *)(node); 
+}
+
+int stop_timer(void *timer )
+{
+  // stop timer if its running
+  // delete the timer from the sorted list
+  struct timer *node = (struct timer *)timer;
+  struct timer *temp = NULL; 
+
+  if(IS_CONTROL_INSIDE_CALLBACK(node))
+    return 0;
+
+  pthread_mutex_lock(&timer_lock); 
+
+  // We still search the timer even if caller has given timer pointer..
+  for(temp = head;(temp != NULL) && (temp != node); temp = temp->next);
+
+  if(temp != NULL)
+  {
+    if(temp == head)
+      head = temp->next;
+
+    if(temp->prev)
+      temp->prev->next = temp->next;
+
+    if(temp->next)
+      temp->next->prev = temp;
+
+    free(temp); 
+    
+    pthread_mutex_unlock(&timer_lock); 
+    return 0;
+  }
+  pthread_mutex_unlock(&timer_lock); 
+  return -1;
+}
+
+int timer_running(void *arg)
+{
+  struct timer *temp = (struct timer *)arg;
+  return find_node(temp); 
+}
+
+void init_timer_lib()
+{
+  static int init_done = 0;
+  if(init_done)
+  {
+    return;
+  }
+  init_done = 1;
+  pthread_mutex_init(&timer_lock, NULL); 
+  pthread_t timer_thread;
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+  pthread_create(&timer_thread, &attr, &init_lib, NULL);
+  return;
+}
+
+/* END of public APIs */

--- a/src/mme-app/Makefile
+++ b/src/mme-app/Makefile
@@ -53,7 +53,7 @@ $(TARGET): $(OBJECTS)
 	@mkdir -p $(BUILDDIR)/handlers
 	@mkdir -p $(BUILDDIR)/sec
 	#@echo " $(CC) $(LFLAGS) $^ -o $(TARGET) $(LIB_PATH) -linterface $(LIBS)";
-	$(CC) $(LFLAGS) $^ -o $(TARGET) $(LIB_PATH) -linterface -llog -ljson $(LIBS)
+	$(CC) $(LFLAGS) $^ -o $(TARGET) $(LIB_PATH) -linterface -llog -ljson -llocaltimer $(LIBS)
 
 $(BUILDDIR)/%.o: $(SRCDIR)/%.$(SRCEXT)
 	@mkdir -p $(BUILDDIR)

--- a/src/mme-app/main.c
+++ b/src/mme-app/main.c
@@ -33,6 +33,7 @@
 #include "hash.h"
 #include "ipc_api.h"
 #include "message_queues.h"
+#include "local_timer.h"
 
 /*Globals and externs*/
 extern mme_config g_mme_cfg;
@@ -205,6 +206,19 @@ init_stage_handlers()
 	return SUCCESS;
 }
 
+void mme_tick_timer(void *data)
+{
+    // start timer again.. we dont support multi-shot timer
+    // if we want timer to fire again the start the timer again
+    static int count;
+    time_t t = time(NULL);
+    /* want to keep this code to just make sure time is working fine */
+    log_msg(LOG_INFO, "MME timer callback called Count %d Time %lu ", count++, t);
+    fflush(NULL); /* I dont know why..logs are not coming immediately. */
+    start_timer(10, mme_tick_timer, NULL);
+    return;
+}
+
 /**
  * @brief MME-app main function.
  * @param None
@@ -216,8 +230,15 @@ int main()
 	init_parser("conf/mme.json");
 	parse_mme_conf();
 
+    /* Initlaize timer lib. */
+    init_timer_lib();
+
+    /* Start Tick timer..*/
+    start_timer(10, mme_tick_timer, NULL);
+
 	/*Initialize MME*/
 	init_mme();
+
 
 	/*Initialize workers*/
 	init_stage_handlers();

--- a/src/mme-app/mme_state_machine.c
+++ b/src/mme-app/mme_state_machine.c
@@ -17,8 +17,6 @@
 
 #include<stdio.h>
 #include<unistd.h>
-#include "s11.h"
-#include "s1ap.h"
 
 int
 start_mme()


### PR DESCRIPTION
Code added as a library. App needs to initialize the library before any timer API
is called. TimerCallbacks are made in timerThread context, so app should take care
of locking its subscribers/xxx before proceeding in the callback.
Whatever callback data is passed to timerlib, should have refCnt based freeing mechanism
else, timer lib will hold stale pointer.