### PR TITLE
S1ap Paging patch to integrate with s11 DDN

### DIFF
--- a/include/common/ddn_info.h
+++ b/include/common/ddn_info.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003-2019, Great Software Laboratory Pvt. Ltd.
- *
+ * 
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,15 +16,18 @@
  * limitations under the License.
  */
 
-#ifndef __PAGING_INFO_H_
-#define __PAGING_INFO_H_
+#ifndef __DDN_INFO_H_
+#define __DDN_INFO_H_
 
-struct paging_Q_msg {
+/*Reference - 29.274 - section 7.2.11*/
+struct DDN_Q_msg {
 	int ue_idx;
-	unsigned char IMSI[BINARY_IMSI_LEN];
-	struct TAI tai;
+	unsigned char eps_bearer_identity;
+
+	/*Allocation/retntion policy*/
+	/*Paging and service informatin*/
 };
 
-#define S1AP_PAGING_INFO_BUF_SIZE sizeof(struct paging_Q_msg)
+#define S11_DDN_INFO_BUF_SIZE sizeof(struct DDN_Q_msg)
 
-#endif /*_PAGING_INFO_H_*/
+#endif /*_DDN_INFO_H_*/

--- a/include/common/message_queues.h
+++ b/include/common/message_queues.h
@@ -110,4 +110,11 @@ Message queues used across MME, S1ap, S11, S6a
 
 /********* STAGE 3 DETACH END    ***************/
 
+/********* PAGING MESSAGE ***************/
+
+#define S6A_DDN_QUEUE  "/tmp/s1ap/s6ap_DDN_Q"
+#define S1AP_PAGING_QUEUE  "/tmp/s1ap/s1ap_paging_Q"
+
+/********* PAGING END    ***************/
+
 #endif /*__MESSAGE_QUEUES_H*/

--- a/include/common/message_queues.h
+++ b/include/common/message_queues.h
@@ -110,11 +110,11 @@ Message queues used across MME, S1ap, S11, S6a
 
 /********* STAGE 3 DETACH END    ***************/
 
-/********* PAGING MESSAGE ***************/
+/********* DDN/PAGING MESSAGE ***************/
 
-#define S6A_DDN_QUEUE  "/tmp/s1ap/s6ap_DDN_Q"
+#define S11_DDN_QUEUE  "/tmp/s11/s11_DDN_Q"
 #define S1AP_PAGING_QUEUE  "/tmp/s1ap/s1ap_paging_Q"
 
-/********* PAGING END    ***************/
+/********* DDN/PAGING END    ***************/
 
 #endif /*__MESSAGE_QUEUES_H*/

--- a/include/common/paging_info.h
+++ b/include/common/paging_info.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2003-2018, Great Software Laboratory Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __PAGING_INFO_H_
+#define __PAGING_INFO_H_
+
+struct paging_Q_msg {
+	int ue_idx;
+	unsigned char IMSI[BINARY_IMSI_LEN];
+};
+
+#define S1AP_PAGING_INFO_BUF_SIZE sizeof(struct paging_Q_msg)
+
+#endif /*_PAGING_INFO_H_*/

--- a/include/common/paging_info.h
+++ b/include/common/paging_info.h
@@ -20,6 +20,7 @@
 struct paging_Q_msg {
 	int ue_idx;
 	unsigned char IMSI[BINARY_IMSI_LEN];
+	struct TAI tai;
 };
 
 #define S1AP_PAGING_INFO_BUF_SIZE sizeof(struct paging_Q_msg)

--- a/include/mme-app/mme_app.h
+++ b/include/mme-app/mme_app.h
@@ -74,6 +74,7 @@ void* stage8_handler(void *);
 void* detach_stage1_mme_handler(void *);
 void* detach_stage2_handler(void *);
 void* detach_stage3_handler(void *);
+void* DDN_handler(void *);
 
 //for testing, delete it
 void

--- a/include/s1ap/main.h
+++ b/include/s1ap/main.h
@@ -68,6 +68,9 @@ void
 *detach_accept_handler(void *);
 
 void
+*paging_handler(void *);
+
+void
 calculate_mac(uint8_t *int_key, uint32_t seq_no, uint8_t direction,
 		uint8_t bearer, uint8_t *data, uint16_t data_len,
 		uint8_t *mac);

--- a/src/mme-app/handlers/paging.c
+++ b/src/mme-app/handlers/paging.c
@@ -103,9 +103,10 @@ read_next_msg()
 static int
 DDN_processing()
 {
-/*
+#ifdef UNCOMMENT_WHEN_S11_DDN_IS_DONE
+
 	struct DDN_Q_msg *ddn_info = (struct DDN_Q_msg *)buf;
-*/
+
 	struct UE_info *ue_entry ;/* =  GET_UE_ENTRY(ddn_info->ue_idx);*/
 
 	/*Change UE state */
@@ -114,6 +115,7 @@ DDN_processing()
 	/*Collect information for next processing*/
 
 	/*post to next processing*/
+#endif /*UNCOMMENT_WHEN_S11_DDN_IS_DONE*/
 	return SUCCESS;
 }
 
@@ -123,6 +125,9 @@ DDN_processing()
 static int
 post_to_next()
 {
+
+#ifdef UNCOMMENT_WHEN_S11_DDN_IS_DONE
+
 /*
 	struct DDN_Q_msg *ddn_info = (struct DDN_Q_msg *)buf;
 */
@@ -134,7 +139,11 @@ post_to_next()
 	paging_msg.ue_idx = 0;/* ddn_info->ue_idx;*/
 	memcpy(&(paging_msg.IMSI), &(ue_entry->IMSI), BINARY_IMSI_LEN);
 
+	/*TODO: Add TAI information in paging message*/
+
 	write_ipc_channel(g_Q_paging_fd, (char *)&(paging_msg), S1AP_PAGING_INFO_BUF_SIZE);
+
+#endif /*UNCOMMENT_WHEN_S11_DDN_IS_DONE*/
 
 	log_msg(LOG_INFO, "Post for paging processing. SUCCESS\n");
 	return SUCCESS;

--- a/src/mme-app/handlers/paging.c
+++ b/src/mme-app/handlers/paging.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2003-2018, Great Software Laboratory Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <string.h>
+
+#include "mme_app.h"
+#include "ue_table.h"
+#include "err_codes.h"
+#include "message_queues.h"
+#include "ipc_api.h"
+#include "paging_info.h"
+
+/************************************************************************
+Paging handler.
+Flow : 36.413 - release 15 - Section 8.5
+		DDN Request : SGW-->MME 
+--->		Paging MME --> eNB
+**************************************************************************/
+
+/****Globals and externs ***/
+
+extern int g_mme_hdlr_status;
+
+static int g_Q_paging_fd;
+static int g_Q_DDN_fd;
+
+/*Making global just to avoid stack passing*/
+static char DDN_buf[10];//[S6A_DDN_BUF_SIZE];
+/*tmp defined*/
+#define S6A_DDN_BUF_SIZE 10
+
+extern uint32_t paging_counter;
+/****Global and externs end***/
+
+/**
+Initialize the stage settings, Q,
+destination communication etc.
+*/
+static void
+init_stage()
+{
+	log_msg(LOG_INFO, "DDN reader complete: waiting\n");
+	if ((g_Q_DDN_fd  = open_ipc_channel(
+					S6A_DDN_QUEUE, IPC_READ)) == -1){
+		log_msg(LOG_ERROR, "Error in opening reader - DDN"
+				"S6A IPC channel.\n");
+		pthread_exit(NULL);
+	}
+	log_msg(LOG_INFO, "DDN reader complete: Connected\n");
+	g_Q_paging_fd = open_ipc_channel(S1AP_PAGING_QUEUE, IPC_WRITE);
+	if (g_Q_paging_fd == -1) {
+		log_msg(LOG_ERROR, "Error in opening Writer IPC channel:s1ap Paging\n");
+		pthread_exit(NULL);
+	}
+	log_msg(LOG_INFO, "s1ap Paging writer: Connected\n");
+
+	return;
+}
+
+/**
+* Read next message from stage Q for processing.
+*/
+static int
+read_next_msg()
+{
+	int bytes_read=0;
+
+	memset(DDN_buf, 0, S6A_DDN_BUF_SIZE);
+	while (bytes_read < S6A_DDN_BUF_SIZE) {//TODO : Recheck condition
+		if ((bytes_read = read_ipc_channel(
+						g_Q_DDN_fd,
+						DDN_buf,
+						S6A_DDN_BUF_SIZE)) == -1) {
+			log_msg(LOG_ERROR, "Error in reading \n");
+			/* TODO : Add proper error handling */
+		}
+		log_msg(LOG_INFO, "DDN Msg Received - Len: %d\n",
+			bytes_read);
+	}
+
+	return bytes_read;
+}
+
+/**
+* Stage specific message processing.
+*/
+static int
+DDN_processing()
+{
+/*
+	struct DDN_Q_msg *ddn_info = (struct DDN_Q_msg *)buf;
+*/
+	struct UE_info *ue_entry ;/* =  GET_UE_ENTRY(ddn_info->ue_idx);*/
+
+	/*Change UE state */
+	/*DDN throtelling if required*/
+
+	/*Collect information for next processing*/
+
+	/*post to next processing*/
+	return SUCCESS;
+}
+
+/**
+* Post message to next handler of the stage
+*/
+static int
+post_to_next()
+{
+/*
+	struct DDN_Q_msg *ddn_info = (struct DDN_Q_msg *)buf;
+*/
+	struct UE_info *ue_entry ;/* =  GET_UE_ENTRY(ddn_info->ue_idx);*/
+	struct paging_Q_msg paging_msg;
+
+	log_msg(LOG_INFO, "Post for s1ap paging processing.\n");
+
+	paging_msg.ue_idx = 0;/* ddn_info->ue_idx;*/
+	memcpy(&(paging_msg.IMSI), &(ue_entry->IMSI), BINARY_IMSI_LEN);
+
+	write_ipc_channel(g_Q_paging_fd, (char *)&(paging_msg), S1AP_PAGING_INFO_BUF_SIZE);
+
+	log_msg(LOG_INFO, "Post for paging processing. SUCCESS\n");
+	return SUCCESS;
+}
+
+/**
+* Thread exit function for future reference.
+*/
+void
+shutdown_paging()
+{
+	close_ipc_channel(g_Q_DDN_fd);
+	close_ipc_channel(g_Q_paging_fd);
+	log_msg(LOG_INFO, "Shutdown DDN/Paging handlers. \n");
+	pthread_exit(NULL);
+	return;
+}
+
+/**
+* Thread function for stage.
+*/
+void*
+DDN_handler(void *data)
+{
+	init_stage();
+	log_msg(LOG_INFO, "DDN stage ready.\n");
+	g_mme_hdlr_status <<= 1;
+	g_mme_hdlr_status |= 1;
+	check_mme_hdlr_status();
+
+	while(1){
+		read_next_msg();
+
+		DDN_processing();
+
+		post_to_next();
+		paging_counter++;
+	}
+
+	return NULL;
+}

--- a/src/mme-app/main.c
+++ b/src/mme-app/main.c
@@ -59,7 +59,7 @@ void
 check_mme_hdlr_status()
 {
 	/*TODO: not thread-safe*/
-	if(!(g_mme_hdlr_status ^ 511)) /*111111111 - 1 bit for init of 1 stage */
+	if(!(g_mme_hdlr_status ^ 1023)) /*11 1111 1111 - 1 bit for init of 1 stage */
 		log_msg(LOG_INFO, "MME setup is ready. Let's dance.\n");
 }
 
@@ -172,6 +172,12 @@ init_mme()
 
 	unlink(S1AP_CTXRELRESP_STAGE3_QUEUE);
 	create_ipc_channel(S1AP_CTXRELRESP_STAGE3_QUEUE);
+
+	unlink(S6A_DDN_QUEUE);
+	create_ipc_channel(S6A_DDN_QUEUE);
+
+	unlink(S1AP_PAGING_QUEUE);
+	create_ipc_channel(S1AP_PAGING_QUEUE);
 	return SUCCESS;
 }
 
@@ -201,6 +207,7 @@ init_stage_handlers()
 	pthread_create(&stage_tid[8], &attr, &detach_stage1_mme_handler, NULL);
 	pthread_create(&stage_tid[9], &attr, &detach_stage2_handler, NULL);
 	pthread_create(&stage_tid[10], &attr, &detach_stage3_handler, NULL);
+	pthread_create(&stage_tid[10], &attr, &DDN_handler, NULL);
 	pthread_attr_destroy(&attr);
 	return SUCCESS;
 }

--- a/src/mme-app/main.c
+++ b/src/mme-app/main.c
@@ -59,7 +59,7 @@ void
 check_mme_hdlr_status()
 {
 	/*TODO: not thread-safe*/
-	if(!(g_mme_hdlr_status ^ 1023)) /*11 1111 1111 - 1 bit for init of 1 stage */
+	if(!(g_mme_hdlr_status ^ 0x3FF)) /*11 1111 1111 - 1 bit for init of 1 stage */
 		log_msg(LOG_INFO, "MME setup is ready. Let's dance.\n");
 }
 
@@ -173,8 +173,8 @@ init_mme()
 	unlink(S1AP_CTXRELRESP_STAGE3_QUEUE);
 	create_ipc_channel(S1AP_CTXRELRESP_STAGE3_QUEUE);
 
-	unlink(S6A_DDN_QUEUE);
-	create_ipc_channel(S6A_DDN_QUEUE);
+	unlink(S11_DDN_QUEUE);
+	create_ipc_channel(S11_DDN_QUEUE);
 
 	unlink(S1AP_PAGING_QUEUE);
 	create_ipc_channel(S1AP_PAGING_QUEUE);

--- a/src/mme-app/stats.c
+++ b/src/mme-app/stats.c
@@ -56,7 +56,6 @@ void* stat_report(void *data)
 
 		printf("Dtch_Stg1       Dtch_Stg2       Dtch_Stg3\n\n");
 		printf("%8u        %8u        %8u\n",detach_stage1_counter,detach_stage2_counter,detach_stage3_counter);
-		sleep(3);
 
 		printf("paging\n\n");
 		printf("%8u\n",paging_counter);

--- a/src/mme-app/stats.c
+++ b/src/mme-app/stats.c
@@ -37,6 +37,8 @@ uint32_t detach_stage1_counter = 0;
 uint32_t detach_stage2_counter = 0;
 uint32_t detach_stage3_counter = 0;
 
+uint32_t paging_counter = 0;
+
 
 void* stat_report(void *data)
 {
@@ -56,6 +58,9 @@ void* stat_report(void *data)
 		printf("%8u        %8u        %8u\n",detach_stage1_counter,detach_stage2_counter,detach_stage3_counter);
 		sleep(3);
 
+		printf("paging\n\n");
+		printf("%8u\n",paging_counter);
+		sleep(3);
 	}
 
 	return NULL;

--- a/src/s1ap/handlers/paging.c
+++ b/src/s1ap/handlers/paging.c
@@ -89,18 +89,22 @@ read_next_msg()
 static int
 paging_processing()
 {
-struct s1ap_PDU s1apPDU;
-
 	g_paging_buf = (struct paging_Q_msg *) buf;
+#ifdef REPLACE_WITH_S1AP_ENCODING_DONE
+	struct s1ap_PDU s1apPDU;
+
 	ProtocolIE_Container_129P22_t paging_buf;
 	PagingIEs_t *paging_ie = NULL;
 
 	paging_buf.list.count = 1;
 	
-	paging_ie = &(paging_buf.list.array[0]);
+	//paging_ie = &(paging_buf.list.array[0]);
 
 	paging_ie->id = ProtocolIE_ID_id_UEPagingID;
 
+	/*TODO : Write code for encoding Paging s1ap API*/
+
+#endif /*REPLACE_WITH_S1AP_ENCODING_DONE*/
 	return SUCCESS;
 }
 
@@ -110,7 +114,8 @@ struct s1ap_PDU s1apPDU;
 static int
 post_to_next()
 {
-//	send_sctp_msg(g_authreqInfo->enb_fd, g_buffer.buf, g_buffer.pos, 1);
+/*TODO : uncomment this to send message when s1ap encoding is done.
+	send_sctp_msg(g_authreqInfo->enb_fd, g_buffer.buf, g_buffer.pos, 1);*/
 	log_msg(LOG_INFO, "\n-----Paging request completed.---\n");
 	return SUCCESS;
 }

--- a/src/s1ap/handlers/paging.c
+++ b/src/s1ap/handlers/paging.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2003-2018, Great Software Laboratory Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "ProtocolIE-Container.h"
+#include "ProtocolIE-ID.h"
+#include "ProtocolIE-Field.h"
+#include "log.h"
+#include "err_codes.h"
+#include "s1ap.h"
+#include "message_queues.h"
+#include "ipc_api.h"
+#include "main.h"
+#include "sctp_conn.h"
+#include "paging_info.h"
+
+/****Globals and externs ***/
+
+/*Making global just to avoid stack passing*/
+static char buf[S1AP_PAGING_INFO_BUF_SIZE];
+extern ipc_handle ipcHndl_paging;
+
+static struct paging_Q_msg *g_paging_buf;
+
+/****Global and externs end***/
+
+/**
+Initialize the stage settings, Q,
+destination communication etc.
+*/
+static void
+init_stage()
+{
+	if ((ipcHndl_paging  = open_ipc_channel(
+				S1AP_PAGING_QUEUE, IPC_READ)) == -1) {
+		log_msg(LOG_ERROR, "Error in opening reader for Paging"
+				"channel : %s\n", S1AP_PAGING_QUEUE);
+		pthread_exit(NULL);
+	}
+	log_msg(LOG_INFO, "Paging reader: Connected.\n");
+
+	return;
+}
+
+/**
+* Read next message from stage Q for processing.
+*/
+static int
+read_next_msg()
+{
+	int bytes_read=0;
+
+	memset(buf, 0, S1AP_PAGING_INFO_BUF_SIZE);
+	while (bytes_read < S1AP_PAGING_INFO_BUF_SIZE) {//TODO : Recheck condition
+		if ((bytes_read = read_ipc_channel(
+				ipcHndl_paging, buf,
+				S1AP_PAGING_INFO_BUF_SIZE)) == -1) {
+					log_msg(LOG_ERROR, "Error reading paging req Q\n");
+					/* TODO : Add proper error handling */
+				}
+		log_msg(LOG_INFO, "Paging recvd from mme on Q len-%d\n", bytes_read);
+	}
+
+	return bytes_read;
+}
+
+
+/**
+* Stage specific message processing.
+*/
+static int
+paging_processing()
+{
+struct s1ap_PDU s1apPDU;
+
+	g_paging_buf = (struct paging_Q_msg *) buf;
+	ProtocolIE_Container_129P22_t paging_buf;
+	PagingIEs_t *paging_ie = NULL;
+
+	paging_buf.list.count = 1;
+	
+	paging_ie = &(paging_buf.list.array[0]);
+
+	paging_ie->id = ProtocolIE_ID_id_UEPagingID;
+
+	return SUCCESS;
+}
+
+/**
+* Post message to next handler of the stage
+*/
+static int
+post_to_next()
+{
+//	send_sctp_msg(g_authreqInfo->enb_fd, g_buffer.buf, g_buffer.pos, 1);
+	log_msg(LOG_INFO, "\n-----Paging request completed.---\n");
+	return SUCCESS;
+}
+
+/**
+* Thread exit function for future reference.
+*/
+void
+shutdown_paging()
+{
+	close_ipc_channel(ipcHndl_paging);
+	pthread_exit(NULL);
+	return;
+}
+
+/**
+* Thread function for stage.
+*/
+void*
+paging_handler(void *data)
+{
+	init_stage();
+	log_msg(LOG_INFO, "Paging handler ready.\n");
+
+	while(1){
+		read_next_msg();
+
+		paging_processing();
+
+		post_to_next();
+	}
+
+	return NULL;
+}

--- a/src/s1ap/handlers/paging.c
+++ b/src/s1ap/handlers/paging.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2003-2018, Great Software Laboratory Pvt. Ltd.
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/s1ap/main.c
+++ b/src/s1ap/main.c
@@ -60,6 +60,7 @@ ipc_handle ipcHndl_smc;
 ipc_handle ipcHndl_esm;
 ipc_handle ipcHndl_ics;
 ipc_handle ipcHndl_detach_accept;
+ipc_handle ipcHndl_paging;
 
 ipc_handle ipcHndl_sctpsend_reader;
 ipc_handle ipcHndl_sctpsend_writer;
@@ -70,6 +71,7 @@ pthread_t esmReq_t;
 pthread_t icsReq_t;
 pthread_t detachAcpt_t;
 pthread_t acceptSctp_t;
+pthread_t paging_t;
 
 struct time_stat g_attach_stats[65535];
 /**End: global and externs**/
@@ -392,6 +394,7 @@ start_mme_resp_handlers()
 	pthread_create(&esmReq_t, &attr, &esmreq_handler, NULL);
 	pthread_create(&icsReq_t, &attr, &icsreq_handler, NULL);
 	pthread_create(&detachAcpt_t, &attr, &detach_accept_handler, NULL);
+	pthread_create(&paging_t, &attr, &paging_handler, NULL);
 
 	pthread_attr_destroy(&attr);
 	return SUCCESS;


### PR DESCRIPTION
- Created msg Q for mme-app to s1ap-app for paging message passing
- handler template added in mme-app to listen to s11 DDN .
- s1ap handler to read from Q, generate Paging message and send.

ToDo:
- Integrate with S11-DDN patch.
- Paging encoding using asn1c gen code.
- Integration testing.