### PR TITLE
EDGEPOD-87 : PLMN Id support in s6a interface

### DIFF
--- a/src/mme-app/handlers/attach_csresp.c
+++ b/src/mme-app/handlers/attach_csresp.c
@@ -188,6 +188,7 @@ post_to_next()
 
 	memcpy(&(icr_msg.gtp_teid), &(ue_entry->s1u_sgw_u_fteid), sizeof(struct fteid));
 
+	// tai format is compatible with nas interface tai format
 	memcpy(&(icr_msg.tai), &(ue_entry->tai), sizeof(struct TAI));
 
 	/*s1ap handler to use apn name and tai to generate mcc, mcn appended name*/

--- a/src/mme-app/handlers/attach_initue.c
+++ b/src/mme-app/handlers/attach_initue.c
@@ -151,6 +151,41 @@ stage1_processing(struct s6a_Q_msg *s6a_req, struct attachReqRej_info *s1ap_rej,
             return E_FAIL;
     }
 
+    /* Lets update plmnId .... What we received from s1ap is : 214365 and what we need on 
+     * s6a/s11/nas interfaces is - 216354*/
+
+    {
+      unsigned char plmn_byte2 = ue_info->tai.plmn_id.idx[1];
+      unsigned char plmn_byte3 = ue_info->tai.plmn_id.idx[2];
+      unsigned char mnc3 = plmn_byte3 >> 4; //  mnc3
+      unsigned char mnc2 = plmn_byte3 & 0xf; // mnc2
+      unsigned char mnc1 = plmn_byte2 >> 4;  // mnc1
+      unsigned char mcc3  = plmn_byte2 & 0xf; //mcc3
+      // First byte we are not changing             mcc2 mcc1
+      plmn_byte2 = (mnc3 << 4) | mcc3; // 2nd byte on NAS - mnc3 mcc3
+      plmn_byte3 = (mnc2 << 4) | mnc1; // 3rd byte on NAS - <mnc2 mnc1>
+      ue_info->tai.plmn_id.idx[1] = plmn_byte2;
+      ue_info->tai.plmn_id.idx[2] = plmn_byte3;
+    }
+
+    {
+      unsigned char plmn_byte2 = ue_info->utran_cgi.plmn_id.idx[1];
+      unsigned char plmn_byte3 = ue_info->utran_cgi.plmn_id.idx[2];
+      unsigned char mnc3 = plmn_byte3 >> 4; //  mnc3
+      unsigned char mnc2 = plmn_byte3 & 0xf; // mnc2
+      unsigned char mnc1 = plmn_byte2 >> 4;  // mnc1
+      unsigned char mcc3  = plmn_byte2 & 0xf; //mcc3
+      // First byte we are not changing             mcc2 mcc1
+      plmn_byte2 = (mnc3 << 4) | mcc3; // 2nd byte on NAS - mnc3 mcc3
+      plmn_byte3 = (mnc2 << 4) | mnc1; // 3rd byte on NAS - <mnc2 mnc1>
+      ue_info->utran_cgi.plmn_id.idx[1] = plmn_byte2;
+      ue_info->utran_cgi.plmn_id.idx[2] = plmn_byte3;
+    }
+
+
+
+
+
     log_msg(LOG_INFO,"%s - UE info flags %x \n",__FUNCTION__, ue_info->flags);
 
     if(UE_ID_GUTI(ue_info->flags))
@@ -219,7 +254,6 @@ stage1_processing(struct s6a_Q_msg *s6a_req, struct attachReqRej_info *s1ap_rej,
         ue_entry->esm_info_tx_required = ue_info->esm_info_tx_required;
         memcpy(&(ue_entry->tai), &(ue_info->tai),
                         sizeof(struct TAI));
-
         memcpy(&(ue_entry->utran_cgi), &(ue_info->utran_cgi),
                         sizeof(struct CGI));
         memcpy(&ue_entry->pco_options[0], &ue_info->pco_options[0], sizeof(ue_info->pco_options)); 

--- a/src/s1ap/handlers/attach_icsreq.c
+++ b/src/s1ap/handlers/attach_icsreq.c
@@ -204,19 +204,8 @@ get_icsreq_protoie_value(struct proto_IE *value)
 
 	nasIEs[nasIeCnt].pduElement.tailist.type = 1;
 	nasIEs[nasIeCnt].pduElement.tailist.num_of_elements = 0;
-    /* S1AP TAI mcc 123, mnc 456 : 214365 */
-    /* NAS GUTI mcc 123, mnc 456 : 216354 */
-    unsigned char x3 = g_icsReqInfo->tai.plmn_id.idx[2]; 
-    unsigned char x2 = g_icsReqInfo->tai.plmn_id.idx[1]; 
-    unsigned char x31 = x3 >> 4;
-    unsigned char x32 = x3 & 0xf;
-    unsigned char x21 = x2 >> 4;
-    unsigned char x22  = x2 & 0xf;
-    x3 = x21 | (x32 <<4);
-    x2 = (x31 << 4) | x22;
-    g_icsReqInfo->tai.plmn_id.idx[1] = x2;
-    g_icsReqInfo->tai.plmn_id.idx[2] = x3;
-
+    	/* S1AP TAI mcc 123, mnc 456 : 214365 */
+    	/* NAS TAI mcc 123, mnc 456 : 216354 */
 	memcpy(&(nasIEs[nasIeCnt].pduElement.tailist.partial_list[0]),
 			&(g_icsReqInfo->tai), sizeof(g_icsReqInfo->tai));
 	nasIeCnt++;

--- a/src/s1ap/handlers/s1ap_tau_response_handler.c
+++ b/src/s1ap/handlers/s1ap_tau_response_handler.c
@@ -314,26 +314,15 @@ s1ap_tau_rsp_processing(void)
 	u8value = 246; /* TODO: remove hard coding */
 	buffer_copy(&g_buffer, &u8value, sizeof(u8value));
 
-    unsigned char x3 = tau_resp->tai.plmn_id.idx[2]; 
-    unsigned char x2 = tau_resp->tai.plmn_id.idx[1]; 
-    unsigned char x31 = x3 >> 4;
-    unsigned char x32 = x3 & 0xf;
-    unsigned char x21 = x2 >> 4;
-    unsigned char x22  = x2 & 0xf;
-    x3 = x21 | (x32 <<4);
-    x2 = (x31 << 4) | x22;
-    tau_resp->tai.plmn_id.idx[1] = x2;
-    tau_resp->tai.plmn_id.idx[2] = x3;
-
 	buffer_copy(&g_buffer, &tau_resp->tai.plmn_id, 3);
 
-    uint16_t grpid = htons(g_s1ap_cfg.mme_group_id);
+	uint16_t grpid = htons(g_s1ap_cfg.mme_group_id);
 	buffer_copy(&g_buffer, &grpid, sizeof(grpid)); 
 
-    u8value = g_s1ap_cfg.mme_code;
+	u8value = g_s1ap_cfg.mme_code;
 	buffer_copy(&g_buffer, &u8value, sizeof(u8value));
 
-    uint32_t mtmsi = htonl(tau_resp->m_tmsi); 
+	uint32_t mtmsi = htonl(tau_resp->m_tmsi); 
 	buffer_copy(&g_buffer, &(mtmsi), sizeof(mtmsi));
 #endif
 
@@ -345,10 +334,10 @@ s1ap_tau_rsp_processing(void)
 	datalen = 0x05;
 	buffer_copy(&g_buffer, &datalen, sizeof(datalen));
     
-    u8value = 0xf4; //
+	u8value = 0xf4; //
 	buffer_copy(&g_buffer, &u8value, sizeof(u8value));
 
-    mtmsi = htonl(tau_resp->ue_idx); 
+    	mtmsi = htonl(tau_resp->ue_idx); 
 	buffer_copy(&g_buffer, &(mtmsi), sizeof(mtmsi));
 #endif
 	/* NAS PDU end */

--- a/src/s1ap/json_config.c
+++ b/src/s1ap/json_config.c
@@ -65,9 +65,13 @@ parse_s1ap_conf()
 	mnc_dig3 = get_int_scalar("mme.mnc.dig3");
 	if(E_PARSING_FAILED == mcc_dig1) return E_PARSING_FAILED;
 
+	/*Carefuly note the s1ap protocol mcc+mnc coding 
+	 * if mcc = 123, mnc 456 then plmnId - 214365. 
+	 * this is octed string encodingas per 36.413 Section - 9.2.3.8  
+	*/
 	g_s1ap_cfg.mme_plmn_id.idx[0] = mcc_dig2 << 4 | mcc_dig1;
-	g_s1ap_cfg.mme_plmn_id.idx[1] = mnc_dig3 << 4 | mcc_dig3;
-	g_s1ap_cfg.mme_plmn_id.idx[2] = mnc_dig2 << 4 | mnc_dig1;
+	g_s1ap_cfg.mme_plmn_id.idx[1] = mnc_dig1 << 4 | mcc_dig3;
+	g_s1ap_cfg.mme_plmn_id.idx[2] = mnc_dig3 << 4 | mnc_dig2;
 
 	return SUCCESS;
 }

--- a/src/s6a/handlers/s6a_req_handler.c
+++ b/src/s6a/handlers/s6a_req_handler.c
@@ -162,7 +162,6 @@ send_FD_ULR(struct s6a_Q_msg *aia_msg, char imsi[])
 
 	/*AVP: Visited-PLMN-Id*/
 	val.os.data = (unsigned char*)aia_msg->tai.plmn_id.idx;
-    aia_msg->tai.plmn_id.idx[2] = 0x10;
 	val.os.len = 3;
 	add_fd_msg(&val, g_fd_dict_objs.visited_PLMN_id, &fd_msg);
 


### PR DESCRIPTION
Plmn id is required on 4 interfaces. s1ap, nas, s6a and s11.
s1ap has different format compared to nas, s6a & s11.
Now UE record has the format which is good for 3 interfaces.
`