### PR TITLE
Initial UE detach and purge fix, Ctx Release cmd encoding fix

### DIFF
--- a/src/mme-app/handlers/detach_req.c
+++ b/src/mme-app/handlers/detach_req.c
@@ -133,16 +133,18 @@ detach_stage1_processing()
 {
 	struct detach_req_Q_msg *detach_req =
 			(struct detach_req_Q_msg *) detachreq;
-	struct UE_info *ue_entry = NULL; 
-
+	struct UE_info *ue_entry = NULL;
+    unsigned int ue_index = -1;
     if(detach_req->ue_idx != -1)
     {
 	    ue_entry = GET_UE_ENTRY(detach_req->ue_idx);
+        ue_index = detach_req->ue_idx;
     }
     else if (detach_req->ue_m_tmsi != -1)
     {
-        unsigned int ue_index = g_tmsi_allocation_array[detach_req->ue_idx]; 
+        ue_index = g_tmsi_allocation_array[detach_req->ue_m_tmsi]; 
 	    ue_entry = GET_UE_ENTRY(ue_index);
+
     }
     else
         return E_FAIL;
@@ -152,12 +154,12 @@ detach_stage1_processing()
        (UNASSIGNED_ENTRY == ue_entry->ue_state) || 
        (!IS_VALID_UE_INFO(ue_entry)))
     {
-        log_msg(LOG_ERROR, "UE Entry invalid. Drop the packet. UE index %d", detach_req->ue_idx);
-        return SUCCESS;
+        log_msg(LOG_ERROR, "UE Entry invalid. Drop the packet. UE index %d , TMSI : %d\n", 
+                 detach_req->ue_idx, detach_req->ue_m_tmsi);
+        return E_FAIL;
     }
 
-	log_msg(LOG_INFO, "Detach request received for ue %d\n",
-			detach_req->ue_idx);
+	log_msg(LOG_INFO, "Detach request received for ue %d\n", ue_index);
 	ue_entry->ul_seq_no++;
 	ue_entry->s1ap_enb_ue_id = detach_req->s1ap_enb_ue_id;
 
@@ -169,7 +171,7 @@ detach_stage1_processing()
 	memcpy(&(g_ds_msg.s11_sgw_c_fteid),
 			&(ue_entry->s11_sgw_c_fteid),
 			sizeof(ue_entry->s11_sgw_c_fteid));
-	g_purge_msg.ue_idx = detach_req->ue_idx;
+	g_purge_msg.ue_idx = ue_index;
 	memcpy(g_purge_msg.IMSI, ue_entry->IMSI, BINARY_IMSI_LEN);
 
 	return SUCCESS;

--- a/src/mme-app/handlers/paging.c
+++ b/src/mme-app/handlers/paging.c
@@ -121,6 +121,7 @@ DDN_processing()
 	if (ue_entry == NULL || !IS_VALID_UE_INFO(ue_entry)) {
 		ddn_ack_msg.cause = GTPV2C_CAUSE_CONTEXT_NOT_FOUND;
         log_msg(LOG_ERROR, "Invalid UE. Send Context not found in DDN Ack ");
+        return -1;
 	} else {
 		ddn_ack_msg.cause = GTPV2C_CAUSE_REQUEST_ACCEPTED;
 		// populate page msg struct

--- a/src/s1ap/handlers/s1ap_encoder.c
+++ b/src/s1ap/handlers/s1ap_encoder.c
@@ -90,10 +90,10 @@ int s1ap_mme_encode_service_rej(
 
     log_msg(LOG_DEBUG, "Encode Serivce Rej");
     pdu.present = S1AP_PDU_PR_initiatingMessage;
-    pdu.choice.initiatingMessage = (InitiatingMessage_t*)malloc(sizeof(InitiatingMessage_t));
+    pdu.choice.initiatingMessage = calloc(sizeof(InitiatingMessage_t), sizeof(uint8_t));
     if(pdu.choice.initiatingMessage == NULL)
     {
-        log_msg(LOG_ERROR,"malloc failed.\n");
+        log_msg(LOG_ERROR,"calloc failed.\n");
         return -1;
     }
     initiating_msg = pdu.choice.initiatingMessage;
@@ -137,8 +137,7 @@ int s1ap_mme_encode_service_rej(
 	buffer_copy(&g_nas_buffer, &value, sizeof(value));
 
     val[2].value.choice.NAS_PDU.size = g_nas_buffer.pos;
-    val[2].value.choice.NAS_PDU.buf = (uint8_t*)malloc(
-                                        sizeof(uint8_t)*(g_nas_buffer.pos));
+    val[2].value.choice.NAS_PDU.buf = calloc(g_nas_buffer.pos, sizeof(uint8_t));
 
     if(val[2].value.choice.NAS_PDU.buf != NULL)
     {
@@ -181,10 +180,10 @@ int s1ap_mme_encode_attach_rej(
 
     log_msg(LOG_DEBUG, "Encode Attach Reject");
     pdu.present = S1AP_PDU_PR_initiatingMessage;
-    pdu.choice.initiatingMessage = (InitiatingMessage_t*)malloc(sizeof(InitiatingMessage_t));
+    pdu.choice.initiatingMessage = calloc(sizeof(InitiatingMessage_t), sizeof(uint8_t));
     if(pdu.choice.initiatingMessage == NULL)
     {
-        log_msg(LOG_ERROR,"malloc failed.\n");
+        log_msg(LOG_ERROR,"calloc failed.\n");
         return -1;
     }
     initiating_msg = pdu.choice.initiatingMessage;
@@ -228,8 +227,7 @@ int s1ap_mme_encode_attach_rej(
 	buffer_copy(&g_nas_buffer, &value, sizeof(value));
 
     val[2].value.choice.NAS_PDU.size = g_nas_buffer.pos;
-    val[2].value.choice.NAS_PDU.buf = (uint8_t*)malloc(
-                                        sizeof(uint8_t)*(g_nas_buffer.pos));
+    val[2].value.choice.NAS_PDU.buf = (uint8_t*)calloc(g_nas_buffer.pos, sizeof(uint8_t));
 
     if(val[2].value.choice.NAS_PDU.buf != NULL)
     {
@@ -264,6 +262,8 @@ int s1ap_mme_encode_ue_context_release_command(
   uint8_t **buffer,
   uint32_t *length)
 {
+	log_msg(LOG_DEBUG,"Inside s1ap_encoder\n");
+
 	S1AP_PDU_t                              pdu = {(S1AP_PDU_PR_NOTHING)};
     InitiatingMessage_t *initiating_msg = NULL;
 	S1AP_PDU_t                             *pdu_p = &pdu;
@@ -271,10 +271,10 @@ int s1ap_mme_encode_ue_context_release_command(
 	memset ((void *)pdu_p, 0, sizeof (S1AP_PDU_t));
 
     pdu.present = S1AP_PDU_PR_initiatingMessage;
-    pdu.choice.initiatingMessage = (InitiatingMessage_t*)malloc(sizeof(InitiatingMessage_t));
+    pdu.choice.initiatingMessage = calloc(sizeof(InitiatingMessage_t), sizeof(uint8_t));
     if(pdu.choice.initiatingMessage == NULL)
     {
-        log_msg(LOG_ERROR,"malloc failed.\n");
+        log_msg(LOG_ERROR,"calloc failed.\n");
         return -1;
     }
     initiating_msg = pdu.choice.initiatingMessage;
@@ -297,10 +297,10 @@ int s1ap_mme_encode_ue_context_release_command(
         ue_id_val.present = UE_S1AP_IDs_PR_uE_S1AP_ID_pair;
         s1apId_pair.eNB_UE_S1AP_ID = s1apPDU->enb_s1ap_ue_id;
         s1apId_pair.mME_UE_S1AP_ID = s1apPDU->mme_s1ap_ue_id;
-        ue_id_val.choice.uE_S1AP_ID_pair = (struct UE_S1AP_ID_pair*)malloc(sizeof(struct UE_S1AP_ID_pair));
+        ue_id_val.choice.uE_S1AP_ID_pair = calloc(sizeof(struct UE_S1AP_ID_pair), sizeof(uint8_t));
         if(ue_id_val.choice.uE_S1AP_ID_pair == NULL)
         {
-            log_msg(LOG_ERROR,"malloc failed.\n");
+            log_msg(LOG_ERROR,"calloc failed.\n");
             free(pdu.choice.initiatingMessage);
             return -1;
         }
@@ -575,7 +575,7 @@ int s1ap_mme_encode_paging_request(
     pagingId.choice.s_TMSI = calloc(sizeof(struct S_TMSI), sizeof(uint8_t));
     if(pagingId.choice.s_TMSI == NULL)
     {
-        log_msg(LOG_ERROR,"malloc failed.\n");
+        log_msg(LOG_ERROR,"calloc failed.\n");
         free(pdu.choice.initiatingMessage);
         return -1;
     }
@@ -583,7 +583,7 @@ int s1ap_mme_encode_paging_request(
     pagingId.choice.s_TMSI->mMEC.buf = calloc(1, sizeof(uint8_t));
     if(NULL == pagingId.choice.s_TMSI->mMEC.buf)
     {
-        log_msg(LOG_ERROR,"malloc failed.\n");
+        log_msg(LOG_ERROR,"calloc failed.\n");
         free(pdu.choice.initiatingMessage);
         free(pagingId.choice.s_TMSI);
         return -1;
@@ -595,7 +595,7 @@ int s1ap_mme_encode_paging_request(
     pagingId.choice.s_TMSI->m_TMSI.buf = calloc(sizeof(uint32_t), sizeof(uint8_t));
     if(NULL == pagingId.choice.s_TMSI->m_TMSI.buf)
     {
-        log_msg(LOG_ERROR,"malloc failed.\n");
+        log_msg(LOG_ERROR,"calloc failed.\n");
         free(pdu.choice.initiatingMessage);
         free(pagingId.choice.s_TMSI);
         free(pagingId.choice.s_TMSI->mMEC.buf);

--- a/src/s1ap/handlers/s1ap_msg_delegator.c
+++ b/src/s1ap/handlers/s1ap_msg_delegator.c
@@ -506,8 +506,32 @@ parse_nas_pdu(char *msg,  int nas_msg_len, struct nasPDU *nas,
             nas->elements = calloc(sizeof(nas_pdu_elements), 1);
 
             /*EPS mobility identity*/
-            memcpy(&(nas->elements[0].pduElement.mi_guti), msg + 1, sizeof(guti));
-            log_msg(LOG_INFO, "M-TMSI - %d\n", nas->elements[0].pduElement.mi_guti.m_TMSI);
+            uint8_t msg_len = msg[1];
+            unsigned char eps_identity = msg[2] & 0x07;
+            log_msg(LOG_INFO, "NAS Detach Request Rcvd :  %d %d %d %d, eps id %d\n", msg[0],msg[1],msg[2],msg[4],eps_identity); 
+            if(eps_identity == 0x06)
+            {
+                log_msg(LOG_INFO, "Mobile identity GUTI Rcvd \n");
+                // Mobile Identity contains GUTI
+                // MCC+MNC offset = 3
+                // MME Group Id   = 2
+                // MME Code       = 1
+                // MTMSI offset from start of this AVP = 3 + 2 + 1
+                nas->elements[0].msgType = NAS_IE_TYPE_EPS_MOBILE_ID_IMSI;
+                memcpy(&nas->elements[0].pduElement.mi_guti.plmn_id.idx, &msg[3], 3);
+                nas->elements[0].pduElement.mi_guti.mme_grp_id = ntohs(*(short int *)(&msg[6]));
+                nas->elements[0].pduElement.mi_guti.mme_code = msg[8];
+                nas->elements[0].pduElement.mi_guti.m_TMSI = ntohl(*((unsigned int *)(&msg[9])));
+                log_msg(LOG_INFO, "NAS Detach Request Rcvd ID: GUTI. PLMN id %d %d %d \n", nas->elements[0].pduElement.mi_guti.plmn_id.idx[0], 
+                        nas->elements[0].pduElement.mi_guti.plmn_id.idx[1], 
+                        nas->elements[0].pduElement.mi_guti.plmn_id.idx[2] );
+                log_msg(LOG_INFO, "NAS Detach Request Rcvd ID: GUTI. mme group id = %d, MME code %d  mtmsi = %d\n", 
+                        nas->elements[0].pduElement.mi_guti.mme_grp_id, 
+                        nas->elements[0].pduElement.mi_guti.mme_code,
+                        nas->elements[0].pduElement.mi_guti.m_TMSI);
+                nas->flags |= NAS_MSG_UE_IE_GUTI;
+            }
+            
             break;
         }
 


### PR DESCRIPTION
1. Added handling in Mme-app and s1ap-app to use TMSI to identify the UE context in case of Initial UE detach.
2. Malloc in Ctx release command encoder was using old memory without clearing. Updated to calloc.