### PR TITLE
Code to send reset message over s1ap interface

### DIFF
--- a/include/common/message_queues.h
+++ b/include/common/message_queues.h
@@ -134,4 +134,7 @@ Message queues used across MME, S1ap, S11, S6a
 
 #define S1AP_TAUREQ_QUEUE  "/tmp/s1ap/s1ap_taureq_Q"
 #define S1AP_TAURSP_QUEUE  "/tmp/s1ap/s1ap_taursp_Q"
+
+#define S1AP_GEN_RESET_QUEUE "/tmp/s1ap/s1ap_gen_reset_Q"
+
 #endif /*__MESSAGE_QUEUES_H*/

--- a/include/common/s1ap_error.h
+++ b/include/common/s1ap_error.h
@@ -1,0 +1,21 @@
+#ifndef __S1AP_ERROR_H_
+#define __S1AP_ERROR_H_
+
+/**
+ When MME wants to reject to s1ap message due to unknown UE context 
+ Refer - 36.413 . 9.1.8.1
+*/
+
+
+struct ue_reset_info {
+	uint32_t enb_fd;
+    uint16_t failure_layer;
+    uint16_t cause;
+    uint32_t reset_type; 
+	uint32_t s1ap_enb_ue_id;
+    uint32_t s1ap_mme_ue_id;
+};
+
+#define UE_RESET_INFO_BUF_SIZE sizeof(struct ue_reset_info)
+
+#endif /*__S1AP_ERROR_H_*/

--- a/include/common/s1ap_error.h
+++ b/include/common/s1ap_error.h
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2019-present Open Networking Foundation
+ * Copyright (c) 2003-2018, Great Software Laboratory Pvt. Ltd.
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #ifndef __S1AP_ERROR_H_
 #define __S1AP_ERROR_H_
 
@@ -12,8 +19,8 @@ struct ue_reset_info {
     uint16_t failure_layer;
     uint16_t cause;
     uint32_t reset_type; 
-	uint32_t s1ap_enb_ue_id;
-    uint32_t s1ap_mme_ue_id;
+	uint32_t enb_s1ap_ue_id;
+    uint32_t mme_s1ap_ue_id;
 };
 
 #define UE_RESET_INFO_BUF_SIZE sizeof(struct ue_reset_info)

--- a/include/common/s1ap_structs.h
+++ b/include/common/s1ap_structs.h
@@ -663,6 +663,7 @@ struct proto_IE {
     uint8_t     ie_cgi_index;
 };
 
+// refer 36.413 . Section 9.3.6 
 enum protocolie_id {
 	id_MME_UE_S1AP_ID = 0,
 	id_Cause = 2,
@@ -672,6 +673,8 @@ enum protocolie_id {
 	id_ERABToBeSetupItemCtxtSUReq = 52,
 	id_uEaggregatedMaximumBitrate = 66,
 	id_SecurityKey = 73,
+    id_ueAssociatedLogicalS1Conn = 91,
+    id_ResetType = 92, 
 	id_UE_S1AP_IDs = 99,
 	id_UESecurityCapabilities = 107,
 };
@@ -700,9 +703,11 @@ enum eps_nas_mesage_type {
 	ESMInformationRequest = 0xd9,
 };
 
+/* Refer 36.413 section - 9.3.6 */
 enum procedure_code {
 	id_InitialContextSetup = 9,
 	id_downlinkNASTransport = 11,
+    id_reset           = 14,
 	id_errorIndication = 15,
 	id_UEContexRelease = 23,
 };

--- a/include/mme-app/mme_app.h
+++ b/include/mme-app/mme_app.h
@@ -14,6 +14,8 @@
 #include "s1ap_structs.h"
 #include "log.h"
 #include "s1ap_emm_message.h"
+#include "s1ap_error.h"
+#include "ue_table.h"
 
 /**
  * MME main application configuration parameters structures.
@@ -93,5 +95,9 @@ void register_config_updates(void);
 void mme_parse_config(mme_config *);
 
 int send_emm_info_s1ap_channel_req(struct ue_emm_info *req);
+
+int send_reset_s1ap_channel_req(struct ue_reset_info *req);
+
+int send_reset (struct UE_info *ue_entry, uint32_t cause, uint32_t reset_type);
 
 #endif /*__MME_APP_H_*/

--- a/include/s1ap/main.h
+++ b/include/s1ap/main.h
@@ -67,6 +67,8 @@ void
 void 
 *tau_response_handler (void *);
 
+void
+*gen_reset_request_handler(void *);
 
 void
 *paging_handler(void *);

--- a/src/mme-app/handlers/attach_complete.c
+++ b/src/mme-app/handlers/attach_complete.c
@@ -17,6 +17,7 @@
 #include "message_queues.h"
 #include "ipc_api.h"
 #include "stage8_info.h"
+#include "s1ap_error.h"
 
 /************************************************************************
 Current file : Stage 7 handler.
@@ -120,7 +121,12 @@ process_MB_resp()
 	memcpy(&(temp.int_key), &(ue_entry->ue_sec_info.int_key), NAS_INT_KEY_SIZE);
     send_emm_info_s1ap_channel_req(&temp); 
 	log_msg(LOG_ERROR, "=====Generate EMM info enb_fd = %d %d \n", temp.enb_fd, ue_entry->enb_fd);
-    
+
+#ifdef DEBUG_RESET
+    // added just for testing 
+    send_reset(ue_entry, 15, 0); 
+#endif
+
 	return mbr_msg->ue_idx;
 }
 

--- a/src/mme-app/handlers/send_reset_s1ap.c
+++ b/src/mme-app/handlers/send_reset_s1ap.c
@@ -1,12 +1,18 @@
+/*
+ * Copyright 2019-present Open Networking Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
 #include <string.h>
-
 #include "mme_app.h"
 #include "err_codes.h"
 #include "message_queues.h"
 #include "ipc_api.h"
+#include "ue_table.h"
 #include "s1ap_error.h"
 
 
@@ -18,9 +24,9 @@ destination communication etc.
 */
 
 void
-send_reset_s1ap_stage_init()
+open_reset_s1ap_stage_init()
 {
-	/*Writing the detach signal to S11 Queue*/
+	/*Writing the reset message to s1ap Queue*/
 	if ((g_Q_reset_s1ap_fd = open_ipc_channel(S1AP_GEN_RESET_QUEUE,
 						IPC_WRITE)) == -1){
 		log_msg(LOG_ERROR, "Error in opening write reset s1ap channel \n");
@@ -30,10 +36,25 @@ send_reset_s1ap_stage_init()
 	return;
 }
 
-static int
-dispatch_reset_s1ap_channel_req(struct ue_reset_info *req)
+int send_reset(struct UE_info *ue_entry, uint32_t cause, uint32_t reset_type)
 {
-	write_ipc_channel(g_Q_reset_s1ap_fd, (char *)&(req), UE_RESET_INFO_BUF_SIZE);
+    /* Generate EMM error only 2 times for test purpose */
+    struct ue_reset_info err = {0};
+    err.enb_fd = ue_entry->enb_fd; 
+    err.enb_s1ap_ue_id = ue_entry->s1ap_enb_ue_id;
+    err.mme_s1ap_ue_id = ue_entry->ue_index;
+    err.reset_type = reset_type;
+    // 3 - Release due to eutran generated reason  
+    // 15 - unknown-pair-ue-s1ap-id 
+    err.cause = cause; 
+    send_reset_s1ap_channel_req(&err); 
+    return 0;
+}
+
+int
+send_reset_s1ap_channel_req(struct ue_reset_info *req)
+{
+	write_ipc_channel(g_Q_reset_s1ap_fd, (char *)(req), UE_RESET_INFO_BUF_SIZE);
 	log_msg(LOG_INFO, "Posted Reset S1ap channel to s1ap-app.\n");
 	return SUCCESS;
 }

--- a/src/mme-app/handlers/send_reset_s1ap.c
+++ b/src/mme-app/handlers/send_reset_s1ap.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <string.h>
+
+#include "mme_app.h"
+#include "err_codes.h"
+#include "message_queues.h"
+#include "ipc_api.h"
+#include "s1ap_error.h"
+
+
+static int g_Q_reset_s1ap_fd;
+
+/**
+Initialize the stage settings, Q,
+destination communication etc.
+*/
+
+void
+send_reset_s1ap_stage_init()
+{
+	/*Writing the detach signal to S11 Queue*/
+	if ((g_Q_reset_s1ap_fd = open_ipc_channel(S1AP_GEN_RESET_QUEUE,
+						IPC_WRITE)) == -1){
+		log_msg(LOG_ERROR, "Error in opening write reset s1ap channel \n");
+		pthread_exit(NULL);
+	}
+	log_msg(LOG_INFO, "Reset S1ap Channel for write opened \n");
+	return;
+}
+
+static int
+dispatch_reset_s1ap_channel_req(struct ue_reset_info *req)
+{
+	write_ipc_channel(g_Q_reset_s1ap_fd, (char *)&(req), UE_RESET_INFO_BUF_SIZE);
+	log_msg(LOG_INFO, "Posted Reset S1ap channel to s1ap-app.\n");
+	return SUCCESS;
+}

--- a/src/mme-app/main.c
+++ b/src/mme-app/main.c
@@ -46,6 +46,7 @@ pthread_t stage_tid[TOTAL_STAGES];
 
 int g_mme_hdlr_status;
 extern void init_backtrace();
+extern void send_reset_s1ap_stage_init(void);
 
 /*End globals and externs*/
 
@@ -218,6 +219,10 @@ init_mme()
 	unlink(S1AP_TAURSP_QUEUE);
 	create_ipc_channel(S1AP_TAURSP_QUEUE);
 
+    //RESET S1AP
+    unlink(S1AP_GEN_RESET_QUEUE);
+    create_ipc_channel(S1AP_TAURSP_QUEUE);
+
 	return SUCCESS;
 }
 
@@ -254,6 +259,7 @@ init_stage_handlers()
 	pthread_create(&stage_tid[15], &attr, &identity_rsp_handler, NULL);
 	pthread_create(&stage_tid[16], &attr, &tau_request_handler, NULL);
   
+    send_reset_s1ap_stage_init(); 
 	if ((g_Q_s1ap_common_reject  = open_ipc_channel(S1AP_MME_TO_S1AP_QUEUE,
 						IPC_WRITE)) == -1){
 		log_msg(LOG_ERROR, "Error in opening MME to S1AP write IPC channel.\n");

--- a/src/mme-app/main.c
+++ b/src/mme-app/main.c
@@ -45,7 +45,7 @@ extern void init_backtrace();
 
 extern void open_emm_info_s1ap_stage_init();
 
-extern void send_reset_s1ap_stage_init(void);
+extern void open_reset_s1ap_stage_init(void);
 
 /*End globals and externs*/
 
@@ -243,9 +243,13 @@ init_stage_handlers()
 	pthread_create(&stage_tid[14], &attr, &service_request_handler, NULL);
 	pthread_create(&stage_tid[15], &attr, &identity_rsp_handler, NULL);
 	pthread_create(&stage_tid[16], &attr, &tau_request_handler, NULL);
-  open_emm_info_s1ap_stage_init();
+
+	/* Just open a pipe. Just one way message, there is no response for this message */
+	open_emm_info_s1ap_stage_init();
   
-    send_reset_s1ap_stage_init(); 
+    /* Just open a pipe. Just one way message we dont want to handle response */
+    open_reset_s1ap_stage_init();
+
 	if ((g_Q_s1ap_common_reject  = open_ipc_channel(S1AP_MME_TO_S1AP_QUEUE,
 						IPC_WRITE)) == -1){
 		log_msg(LOG_ERROR, "Error in opening MME to S1AP write IPC channel.\n");

--- a/src/s1ap/handlers/gen_error_reset.c
+++ b/src/s1ap/handlers/gen_error_reset.c
@@ -3,18 +3,6 @@
 *
 * SPDX-License-Identifier: Apache-2.0
 *
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*  http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -52,7 +40,7 @@ reset_request_processing()
 
 	/* Assigning values to s1apPDU */
 	s1apPDU.procedurecode = id_reset;
-	s1apPDU.criticality = CRITICALITY_IGNORE;
+	s1apPDU.criticality = CRITICALITY_REJECT;
 
 	/* Copy values to buffer from s1apPDU */
 
@@ -82,7 +70,7 @@ reset_request_processing()
         buffer_copy(&g_value_buffer, tmpStr,
                         sizeof(protocolIe_Id));
         
-        uint8_t protocolIe_criticality = CRITICALITY_REJECT;
+        uint8_t protocolIe_criticality = CRITICALITY_IGNORE;
         buffer_copy(&g_value_buffer, &protocolIe_criticality,
                         sizeof(protocolIe_criticality));
         
@@ -122,7 +110,7 @@ reset_request_processing()
           g_ue_associations_buf.pos = 0;
           {
             uint8_t enb_mme; 
-            uint16_t mmeid = g_errorResetS1apInfo->s1ap_mme_ue_id;
+            uint16_t mmeid = g_errorResetS1apInfo->mme_s1ap_ue_id;
             if(mmeid <= 255) 
             {
               enb_mme = 0x60; // eNB & mme s1ap id present and length 1 byte 
@@ -141,8 +129,7 @@ reset_request_processing()
             } 
           }
           {
-            uint8_t enb_mme; 
-            uint16_t enb_id = g_errorResetS1apInfo->s1ap_enb_ue_id;
+            uint16_t enb_id = g_errorResetS1apInfo->enb_s1ap_ue_id;
             if(enb_id <= 255) 
             {
               uint8_t len=0;

--- a/src/s1ap/handlers/gen_error_reset.c
+++ b/src/s1ap/handlers/gen_error_reset.c
@@ -1,0 +1,261 @@
+/*
+* Copyright 2019-present Open Networking Foundation
+*
+* SPDX-License-Identifier: Apache-2.0
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <string.h>
+#include <unistd.h>
+#include "log.h"
+#include "err_codes.h"
+#include "s1ap.h"
+#include "ipc_api.h"
+#include "main.h"
+#include "stage2_info.h"
+#include "message_queues.h"
+#include "sctp_conn.h"
+#include "s1ap_error.h"
+
+/*Making global just to avoid stack passing*/
+static char buf[UE_RESET_INFO_BUF_SIZE];
+extern ipc_handle ipcHndl_reset_message;
+
+static struct ue_reset_info *g_errorResetS1apInfo;
+static struct Buffer g_buffer;
+static struct Buffer g_value_buffer;
+static struct Buffer g_reset_buffer;
+static struct Buffer g_ue_associations_buf;
+
+/**
+* Stage specific message processing.
+*/
+static int
+reset_request_processing()
+{
+	struct s1ap_PDU s1apPDU;
+	g_errorResetS1apInfo = (struct ue_reset_info *) buf;
+
+	/* Assigning values to s1apPDU */
+	s1apPDU.procedurecode = id_reset;
+	s1apPDU.criticality = CRITICALITY_IGNORE;
+
+	/* Copy values to buffer from s1apPDU */
+
+	g_buffer.pos = 0;
+
+	uint8_t initiating_message = 0; 
+	buffer_copy(&g_buffer, &initiating_message,
+			sizeof(initiating_message));
+
+	buffer_copy(&g_buffer, &s1apPDU.procedurecode,
+			sizeof(s1apPDU.procedurecode));
+
+	buffer_copy(&g_buffer, &s1apPDU.criticality,
+			sizeof(s1apPDU.criticality));
+
+	/* Copy values in g_value_buffer */
+	g_value_buffer.pos = 0;
+
+	unsigned char chProtoIENo[3] = {0,0,2}; /*no extension and 2 IEs */
+
+	buffer_copy(&g_value_buffer, chProtoIENo, sizeof(chProtoIENo));
+    /* Add cause */
+    {
+        unsigned char tmpStr[4];
+        uint16_t protocolIe_Id = id_Cause;
+        copyU16(tmpStr, protocolIe_Id);
+        buffer_copy(&g_value_buffer, tmpStr,
+                        sizeof(protocolIe_Id));
+        
+        uint8_t protocolIe_criticality = CRITICALITY_REJECT;
+        buffer_copy(&g_value_buffer, &protocolIe_criticality,
+                        sizeof(protocolIe_criticality));
+        
+        uint8_t cause_length = 2; 
+        buffer_copy(&g_value_buffer, &cause_length, sizeof(cause_length));
+        // refer - 36.413 Section 9.1.8.1 
+        uint16_t  final = (g_errorResetS1apInfo->failure_layer << 12) | (g_errorResetS1apInfo->cause << 5); 
+        uint8_t byte=(final >> 8) & 0xff ;
+        buffer_copy(&g_value_buffer, &byte, sizeof(byte));
+        byte=(final) & 0xff ;
+        buffer_copy(&g_value_buffer, &byte, sizeof(byte));
+    }
+    /* Add specific tunnel info to be resetted */
+    {
+        unsigned char tmpStr[4];
+        uint16_t protocolIe_Id = id_ResetType;
+        copyU16(tmpStr, protocolIe_Id);
+        buffer_copy(&g_value_buffer, tmpStr,
+                        sizeof(protocolIe_Id));
+        
+        uint8_t protocolIe_criticality = CRITICALITY_REJECT;
+        buffer_copy(&g_value_buffer, &protocolIe_criticality,
+                        sizeof(protocolIe_criticality));
+
+	    g_reset_buffer.pos = 0;
+        uint8_t reset_type_buf = (1 << 6); 
+        buffer_copy(&g_reset_buffer, &reset_type_buf, sizeof(reset_type_buf));
+        uint8_t no_of_conns = 0; /* Actual tunnels - 1 */ 
+        buffer_copy(&g_reset_buffer, &no_of_conns, sizeof(no_of_conns));
+        {
+    	  unsigned char tmpStr[4];
+	      uint16_t protocolIe_Id = id_ueAssociatedLogicalS1Conn;
+	      copyU16(tmpStr, protocolIe_Id);
+	      buffer_copy(&g_reset_buffer, tmpStr, sizeof(protocolIe_Id));
+	      uint8_t protocolIe_criticality = CRITICALITY_REJECT;
+	      buffer_copy(&g_reset_buffer, &protocolIe_criticality, sizeof(protocolIe_criticality));
+          g_ue_associations_buf.pos = 0;
+          {
+            uint8_t enb_mme; 
+            uint16_t mmeid = g_errorResetS1apInfo->s1ap_mme_ue_id;
+            if(mmeid <= 255) 
+            {
+              enb_mme = 0x60; // eNB & mme s1ap id present and length 1 byte 
+              buffer_copy(&g_ue_associations_buf, &enb_mme, sizeof(enb_mme));
+              uint8_t mme_id = mmeid;
+              buffer_copy(&g_ue_associations_buf, &mme_id, sizeof(mme_id));
+            } 
+            else if (mmeid <= 65535)
+            {
+              enb_mme = 0x64; // eNB & mme s1ap id present and length 1 byte 
+              buffer_copy(&g_ue_associations_buf, &enb_mme, sizeof(enb_mme));
+              uint8_t mme_id1 = (mmeid >> 8) & 0xff;
+              uint8_t mme_id2 = (mmeid) & 0xff;
+              buffer_copy(&g_ue_associations_buf, &mme_id1, sizeof(mme_id1));
+              buffer_copy(&g_ue_associations_buf, &mme_id2, sizeof(mme_id2));
+            } 
+          }
+          {
+            uint8_t enb_mme; 
+            uint16_t enb_id = g_errorResetS1apInfo->s1ap_enb_ue_id;
+            if(enb_id <= 255) 
+            {
+              uint8_t len=0;
+              buffer_copy(&g_ue_associations_buf, &len, sizeof(len));
+              uint8_t enbid = enb_id;
+              buffer_copy(&g_ue_associations_buf, &enbid, sizeof(enbid));
+            } 
+            else if (enb_id <= 65535)
+            {
+              uint8_t len=0x40;
+              buffer_copy(&g_ue_associations_buf, &len, sizeof(len));
+              uint8_t enb_id1 = (enb_id >> 8) & 0xff;
+              uint8_t enb_id2 = (enb_id) & 0xff;
+              buffer_copy(&g_ue_associations_buf, &enb_id1, sizeof(enb_id1));
+              buffer_copy(&g_ue_associations_buf, &enb_id2, sizeof(enb_id2));
+            } 
+          }        
+          // we are done with g_ue_associations_buf. Now lets add that to g_reset_buf  
+          // we are always including only 1 end points ..so we are well within 1 byte length 
+          uint8_t inner_payload = g_ue_associations_buf.pos;
+          buffer_copy(&g_reset_buffer, &inner_payload, sizeof(inner_payload));
+          buffer_copy(&g_reset_buffer, &g_ue_associations_buf.buf[0], g_ue_associations_buf.pos);
+       }
+       uint8_t resettype_payload = g_reset_buffer.pos;
+       buffer_copy(&g_value_buffer, &resettype_payload, sizeof(resettype_payload));
+       buffer_copy(&g_value_buffer, &g_reset_buffer.buf[0], g_reset_buffer.pos);
+    }
+    /* Assumed to be 1 byte ?*/
+    uint8_t top_payload = g_value_buffer.pos;
+    buffer_copy(&g_buffer, &top_payload, sizeof(top_payload));
+    buffer_copy(&g_buffer, &g_value_buffer.buf[0], g_value_buffer.pos);
+	return SUCCESS;
+}
+
+/**
+* Post message to next handler of the stage
+*/
+static int
+post_to_next()
+{
+	send_sctp_msg(g_errorResetS1apInfo->enb_fd, g_buffer.buf, g_buffer.pos, 1);
+	return SUCCESS;
+}
+
+/**
+* Thread exit function for future reference.
+*/
+void
+shutdown_s1ap_reset_pipe()
+{
+	close_ipc_channel(ipcHndl_reset_message);
+	pthread_exit(NULL);
+	return;
+}
+
+/**
+Initialize the stage settings, Q,
+destination communication etc.
+*/
+static void
+init_stage()
+{
+	if ((ipcHndl_reset_message  = open_ipc_channel(
+				S1AP_GEN_RESET_QUEUE, IPC_READ)) == -1) {
+		log_msg(LOG_ERROR, "Error in opening reader for reset queue IPC"
+				"channel : %s\n", S1AP_GEN_RESET_QUEUE);
+		pthread_exit(NULL);
+	}
+	log_msg(LOG_INFO, "s1ap reset queue reader: Connected.\n");
+
+	return;
+}
+
+/**
+* Read next message from stage Q for processing.
+*/
+static int
+read_next_msg()
+{
+	int bytes_read=0;
+
+	memset(buf, 0, UE_RESET_INFO_BUF_SIZE);
+	while (bytes_read < UE_RESET_INFO_BUF_SIZE) {
+		if ((bytes_read = read_ipc_channel(
+				ipcHndl_reset_message, buf,
+				UE_RESET_INFO_BUF_SIZE)) == -1) {
+					log_msg(LOG_ERROR, "Error reading error reset  Q \n");
+					/* TODO : Add proper error handling */
+				}
+		log_msg(LOG_INFO, "S1ap error reset message received from enb Q len-%d", bytes_read);
+	}
+
+	return bytes_read;
+}
+
+
+/**
+* Thread function for stage.
+*/
+void*
+gen_reset_request_handler(void *data)
+{
+	init_stage();
+	log_msg(LOG_INFO, "S1Ap reset message handler ready.\n");
+
+	while(1){
+		read_next_msg();
+
+		reset_request_processing();
+
+		post_to_next();
+	}
+
+	return NULL;
+}
+

--- a/src/s1ap/main.c
+++ b/src/s1ap/main.c
@@ -51,6 +51,7 @@ ipc_handle ipcHndl_identityresp;
 ipc_handle ipcHndl_s1ap_msgs;
 ipc_handle ipcHndl_taureq;
 ipc_handle ipcHndl_taursp;
+ipc_handle ipcHndl_reset_message;
 
 
 ipc_handle ipcHndl_auth;
@@ -76,6 +77,7 @@ pthread_t attachIdReq_t;
 pthread_t paging_t;
 pthread_t mme_to_s1ap_msg_t;
 pthread_t tau_rsp_msg_t;
+pthread_t send_reset_eNB_msg_t;
 
 struct time_stat g_attach_stats[65535];
 /**End: global and externs**/
@@ -430,6 +432,7 @@ start_mme_resp_handlers()
 	pthread_create(&paging_t, &attr, &paging_handler, NULL);
 	pthread_create(&mme_to_s1ap_msg_t, &attr, &mme_to_s1ap_msg_handler, NULL);
 	pthread_create(&tau_rsp_msg_t, &attr, &tau_response_handler, NULL);
+    pthread_create(&send_reset_eNB_msg_t, &attr, &gen_reset_request_handler, NULL);
 
 	pthread_attr_destroy(&attr);
 	return SUCCESS;


### PR DESCRIPTION
Purpose is that MME should be able to generate s1ap reset messages. This would help UE to re-attach the network & stale resources at the eNB will get released.